### PR TITLE
Feature - Import Statements

### DIFF
--- a/compiler/include/astnodes.h
+++ b/compiler/include/astnodes.h
@@ -107,6 +107,7 @@
     NODE(ForeignBlock)         \
                                \
     NODE(Package)              \
+    NODE(Import)               \
                                \
     NODE(ZeroValue)
 
@@ -132,6 +133,7 @@ typedef enum AstKind {
     Ast_Kind_Load_Path,
     Ast_Kind_Load_All,
     Ast_Kind_Library_Path,
+    Ast_Kind_Import,
     Ast_Kind_Memres,
 
     Ast_Kind_Binding,
@@ -1170,6 +1172,13 @@ struct AstPackage {
     Package* package;
 };
 
+struct AstImport {
+    AstNode_base;
+
+    AstPackage *imported_package;
+};
+
+
 //
 // Polymorphic procedures
 //
@@ -1458,6 +1467,7 @@ typedef enum EntityType {
     Entity_Type_Load_File,
     Entity_Type_Binding,
     Entity_Type_Use_Package,
+    Entity_Type_Import,
     Entity_Type_Static_If,
     Entity_Type_String_Literal,
     Entity_Type_File_Contents,
@@ -1511,6 +1521,7 @@ typedef struct Entity {
     union {
         AstDirectiveError     *error;
         AstInclude            *include;
+        AstImport             *import;
         AstBinding            *binding;
         AstIf                 *static_if;
         AstFunction           *function;

--- a/compiler/include/astnodes.h
+++ b/compiler/include/astnodes.h
@@ -1176,6 +1176,8 @@ struct AstImport {
     AstNode_base;
 
     AstPackage *imported_package;
+
+    AstUse *implicit_use_node;
 };
 
 

--- a/compiler/include/astnodes.h
+++ b/compiler/include/astnodes.h
@@ -48,7 +48,6 @@
                                \
     NODE(Return)               \
     NODE(Jump)                 \
-    NODE(Use)                  \
                                \
     NODE(Block)                \
     NODE(IfWhile)              \
@@ -208,7 +207,7 @@ typedef enum AstKind {
     Ast_Kind_For,
     Ast_Kind_While,
     Ast_Kind_Jump,
-    Ast_Kind_Use,
+    // Ast_Kind_Use,
     Ast_Kind_Defer,
     Ast_Kind_Switch,
     Ast_Kind_Switch_Case,
@@ -777,16 +776,16 @@ struct AstDirectiveSolidify {
 struct AstReturn        { AstNode_base; AstTyped* expr; u32 count; }; // Note: This count is one less than it should be, because internal codegen with macros would have to know about this and that is error prone.
 struct AstJump          { AstNode_base; JumpType jump; u32 count; };
 
-typedef struct QualifiedUse {
-    OnyxToken* symbol_name;
-    OnyxToken* as_name;
-} QualifiedUse;
-struct AstUse           {
-    AstNode_base;
-
-    AstTyped* expr;
-    bh_arr(QualifiedUse) only;
-};
+// typedef struct QualifiedUse {
+//     OnyxToken* symbol_name;
+//     OnyxToken* as_name;
+// } QualifiedUse;
+// struct AstUse           {
+//     AstNode_base;
+// 
+//     AstTyped* expr;
+//     bh_arr(QualifiedUse) only;
+// };
 
 // Structure Nodes
 struct AstBlock         {
@@ -1172,12 +1171,30 @@ struct AstPackage {
     Package* package;
 };
 
+typedef struct QualifiedImport {
+    OnyxToken* symbol_name;
+    OnyxToken* as_name;
+} QualifiedImport;
+
 struct AstImport {
     AstNode_base;
 
     AstPackage *imported_package;
 
-    AstUse *implicit_use_node;
+    bh_arr(QualifiedImport) only;
+
+    // When true, it means a list of imports
+    // was specified and the top-level package
+    // should not be imported.
+    b32 specified_imports;
+
+    // When true, even if a list of specified
+    // imports was given, the package name should
+    // also be imported.
+    //
+    //     use core {package, *}
+    //
+    b32 also_import_package;
 };
 
 
@@ -1540,7 +1557,6 @@ typedef struct Entity {
         AstPolyQuery          *poly_query;
         AstForeignBlock       *foreign_block;
         AstMacro              *macro;
-        AstUse                *use;
         AstInterface          *interface;
         AstConstraint         *constraint;
         AstDirectiveLibrary   *library;

--- a/compiler/include/astnodes.h
+++ b/compiler/include/astnodes.h
@@ -207,7 +207,6 @@ typedef enum AstKind {
     Ast_Kind_For,
     Ast_Kind_While,
     Ast_Kind_Jump,
-    // Ast_Kind_Use,
     Ast_Kind_Defer,
     Ast_Kind_Switch,
     Ast_Kind_Switch_Case,
@@ -775,17 +774,6 @@ struct AstDirectiveSolidify {
 // Intruction Node
 struct AstReturn        { AstNode_base; AstTyped* expr; u32 count; }; // Note: This count is one less than it should be, because internal codegen with macros would have to know about this and that is error prone.
 struct AstJump          { AstNode_base; JumpType jump; u32 count; };
-
-// typedef struct QualifiedUse {
-//     OnyxToken* symbol_name;
-//     OnyxToken* as_name;
-// } QualifiedUse;
-// struct AstUse           {
-//     AstNode_base;
-// 
-//     AstTyped* expr;
-//     bh_arr(QualifiedUse) only;
-// };
 
 // Structure Nodes
 struct AstBlock         {

--- a/compiler/include/astnodes.h
+++ b/compiler/include/astnodes.h
@@ -1194,7 +1194,16 @@ struct AstImport {
     //
     //     use core {package, *}
     //
-    b32 also_import_package;
+    b32 import_package_itself;
+
+    // Set to be the symbol that the package will
+    // be imported as. If NULL, the last token of
+    // the package path is used. The following
+    // imports the core package as C.
+    // 
+    //     use core { C :: package }
+    //
+    OnyxToken *qualified_package_name;
 };
 
 

--- a/compiler/src/astnodes.c
+++ b/compiler/src/astnodes.c
@@ -84,7 +84,7 @@ static const char* ast_node_names[] = {
     "FOR",
     "WHILE",
     "JUMP",
-    "USE",
+    // "USE",
     "DEFER",
     "SWITCH",
     "CASE",

--- a/compiler/src/astnodes.c
+++ b/compiler/src/astnodes.c
@@ -84,7 +84,6 @@ static const char* ast_node_names[] = {
     "FOR",
     "WHILE",
     "JUMP",
-    // "USE",
     "DEFER",
     "SWITCH",
     "CASE",

--- a/compiler/src/astnodes.c
+++ b/compiler/src/astnodes.c
@@ -9,6 +9,7 @@ static const char* ast_node_names[] = {
     "INCLUDE FOLDER",
     "INCLUDE ALL IN FOLDER",
     "INCLUDE LIBRARY PATH",
+    "IMPORT",
     "MEMORY RESERVATION",
 
     "BINDING",

--- a/compiler/src/clone.c
+++ b/compiler/src/clone.c
@@ -117,6 +117,7 @@ static inline i32 ast_kind_to_size(AstNode* node) {
         case Ast_Kind_Directive_Remove: return sizeof(AstDirectiveRemove);
         case Ast_Kind_Directive_First: return sizeof(AstDirectiveFirst);
         case Ast_Kind_Directive_Export_Name: return sizeof(AstDirectiveExportName);
+        case Ast_Kind_Import: return sizeof(AstImport);
         case Ast_Kind_Count: return 0;
     }
 

--- a/compiler/src/clone.c
+++ b/compiler/src/clone.c
@@ -100,7 +100,6 @@ static inline i32 ast_kind_to_size(AstNode* node) {
         case Ast_Kind_For: return sizeof(AstFor);
         case Ast_Kind_While: return sizeof(AstIfWhile);
         case Ast_Kind_Jump: return sizeof(AstJump);
-        case Ast_Kind_Use: return sizeof(AstUse);
         case Ast_Kind_Defer: return sizeof(AstDefer);
         case Ast_Kind_Switch: return sizeof(AstSwitch);
         case Ast_Kind_Switch_Case: return sizeof(AstSwitchCase);
@@ -523,10 +522,6 @@ AstNode* ast_clone(bh_allocator a, void* n) {
             dc->phase = Constraint_Phase_Waiting_To_Be_Queued;
             break;
         }
-
-        case Ast_Kind_Use:
-            C(AstUse, expr);
-            break;
 
         case Ast_Kind_Directive_Solidify: {
             AstDirectiveSolidify* dd = (AstDirectiveSolidify *) nn;

--- a/compiler/src/entities.c
+++ b/compiler/src/entities.c
@@ -299,19 +299,6 @@ void add_entities_for_node(bh_arr(Entity *) *target_arr, AstNode* node, Scope* s
             break;
         }
 
-        case Ast_Kind_Use: {
-            if (((AstUse *) node)->expr->kind == Ast_Kind_Package) {
-                ent.state = Entity_State_Resolve_Symbols;
-                ent.type = Entity_Type_Use_Package;
-            } else {
-                ent.type = Entity_Type_Use;
-            }
-
-            ent.use = (AstUse *) node;
-            ENTITY_INSERT(ent);
-            break;
-        }
-
         case Ast_Kind_Memres: {
             ent.type = Entity_Type_Memory_Reservation_Type;
             ent.mem_res = (AstMemRes *) node;

--- a/compiler/src/entities.c
+++ b/compiler/src/entities.c
@@ -400,6 +400,14 @@ void add_entities_for_node(bh_arr(Entity *) *target_arr, AstNode* node, Scope* s
             break;
         }
 
+        case Ast_Kind_Import: {
+            ent.type = Entity_Type_Import;
+            ent.import = (AstImport *) node;
+            ent.state = Entity_State_Resolve_Symbols;
+            ENTITY_INSERT(ent);
+            break;
+        }
+
         default: {
             ent.type = Entity_Type_Expression;
             ent.expr = (AstTyped *) node;

--- a/compiler/src/lex.c
+++ b/compiler/src/lex.c
@@ -38,6 +38,7 @@ static const char* token_type_names[] = {
     "macro",
     "interface",
     "where",
+    "import",
     "", // end
 
     "->",

--- a/compiler/src/lex.c
+++ b/compiler/src/lex.c
@@ -38,7 +38,6 @@ static const char* token_type_names[] = {
     "macro",
     "interface",
     "where",
-    "import",
     "", // end
 
     "->",

--- a/compiler/src/parser.c
+++ b/compiler/src/parser.c
@@ -3619,14 +3619,23 @@ static void parse_import_statement(OnyxParser* parser, OnyxToken *token) {
     import_node->flags |= Ast_Flag_Comptime;
     import_node->token = token;
     import_node->imported_package = package_node;
-    import_node->also_import_package = 1;
+    import_node->import_package_itself = 1;
 
     if (consume_token_if_next(parser, '{')) {
         import_node->specified_imports = 1;
-        import_node->also_import_package = 0;
+        import_node->import_package_itself = 0;
 
-        if (consume_token_if_next(parser, Token_Type_Keyword_Package)) {
-            import_node->also_import_package = 1;
+        if (next_tokens_are(parser, 4, Token_Type_Symbol, ':', ':', Token_Type_Keyword_Package)) {
+            import_node->qualified_package_name = expect_token(parser, Token_Type_Symbol);
+            consume_tokens(parser, 3);
+
+            import_node->import_package_itself = 1;
+            if (parser->curr->type != '}')
+                expect_token(parser, ',');
+        }
+
+        else if (consume_token_if_next(parser, Token_Type_Keyword_Package)) {
+            import_node->import_package_itself = 1;
             if (parser->curr->type != '}')
                 expect_token(parser, ',');
         }

--- a/compiler/src/parser.c
+++ b/compiler/src/parser.c
@@ -1691,13 +1691,6 @@ static AstNode* parse_statement(OnyxParser* parser) {
                 break;
             }
 
-            if (parse_possible_directive(parser, "import")) {
-                // :LinearTokenDependent
-                parse_import_statement(parser, parser->curr - 2);
-                needs_semicolon = 0;
-                break;
-            }
-
             if (next_tokens_are(parser, 2, '#', Token_Type_Symbol)) {
                 retval = (AstNode *) parse_factor(parser);
                 break;
@@ -3499,10 +3492,6 @@ static void parse_top_level_statement(OnyxParser* parser) {
                 expect_token(parser, Token_Type_Literal_String);
                 return;
             }
-            else if (parse_possible_directive(parser, "import")) {
-                parse_import_statement(parser, dir_token);
-                return;
-            }
             else {
                 OnyxToken* directive_token = expect_token(parser, '#');
                 OnyxToken* symbol_token = parser->curr;
@@ -3619,6 +3608,10 @@ static void parse_import_statement(OnyxParser* parser, OnyxToken *token) {
     package_node->flags |= Ast_Flag_Comptime;
     package_node->type_node = builtin_package_id_type;
     package_node->token = token;
+
+    if (peek_token(0)->type == Token_Type_Keyword_Package) {
+        package_node->token = expect_token(parser, Token_Type_Keyword_Package);
+    }
 
     if (!parse_package_name(parser, package_node)) return;
 

--- a/compiler/src/symres.c
+++ b/compiler/src/symres.c
@@ -1768,6 +1768,17 @@ static SymresStatus symres_file_contents(AstFileContents* fc) {
     return Symres_Success;
 }
 
+static SymresStatus symres_import(AstImport* import) {
+    SYMRES(package, import->imported_package);
+
+    symbol_introduce(
+            current_entity->scope,
+            bh_arr_last(import->imported_package->path),
+            (AstNode *) import->imported_package);
+
+    return Symres_Complete;
+}
+
 void symres_entity(Entity* ent) {
     current_entity = ent;
     if (ent->scope) scope_enter(ent->scope);
@@ -1804,6 +1815,9 @@ void symres_entity(Entity* ent) {
         case Entity_Type_Use:                     ss = symres_use(ent->use);
                                                   next_state = Entity_State_Finalized;
                                                   break;
+
+        case Entity_Type_Import:                  ss = symres_import(ent->import); break;
+
 
         case Entity_Type_Polymorphic_Proc:        ss = symres_polyproc(ent->poly_proc);
                                                   next_state = Entity_State_Finalized;

--- a/compiler/src/symres.c
+++ b/compiler/src/symres.c
@@ -974,6 +974,10 @@ static SymresStatus symres_statement(AstNode** stmt, b32 *remove) {
             SYMRES(use, (AstUse *) *stmt);
             break;
 
+        case Ast_Kind_Import:
+            if (remove) *remove = 1;
+            break;
+
         default: SYMRES(expression, (AstTyped **) stmt); break;
     }
 

--- a/compiler/src/symres.c
+++ b/compiler/src/symres.c
@@ -1668,10 +1668,13 @@ static SymresStatus symres_import(AstImport* import) {
     AstPackage* package = import->imported_package;
     SYMRES(package, package);
 
-    if (import->also_import_package) {
+    if (import->import_package_itself) {
+        OnyxToken *name = bh_arr_last(package->path);
+        name = import->qualified_package_name ?: name;    // Had to find somewhere to use the Elvis operator in the codebase :)
+
         symbol_introduce(
                 current_entity->scope,
-                bh_arr_last(package->path),
+                name,
                 (AstNode *) package);
     }
 

--- a/compiler/src/utils.c
+++ b/compiler/src/utils.c
@@ -55,7 +55,17 @@ Package* package_lookup_or_create(char* package_name, Scope* parent_scope, bh_al
 
         shput(context.packages, pac_name, package);
 
-        if (!charset_contains(pac_name, '.')) {
+        // if (!charset_contains(pac_name, '.')) {
+        //     AstPackage* package_node = onyx_ast_node_new(alloc, sizeof(AstPackage), Ast_Kind_Package);
+        //     package_node->package_name = package->name;
+        //     package_node->package = package;
+        //     package_node->type_node = builtin_package_id_type;
+        //     package_node->flags |= Ast_Flag_Comptime;
+
+        //     symbol_raw_introduce(context.global_scope, pac_name, pos, (AstNode *) package_node);
+        // }
+
+        if (!strcmp(pac_name, "builtin")) {
             AstPackage* package_node = onyx_ast_node_new(alloc, sizeof(AstPackage), Ast_Kind_Package);
             package_node->package_name = package->name;
             package_node->package = package;

--- a/compiler/src/utils.c
+++ b/compiler/src/utils.c
@@ -55,16 +55,8 @@ Package* package_lookup_or_create(char* package_name, Scope* parent_scope, bh_al
 
         shput(context.packages, pac_name, package);
 
-        // if (!charset_contains(pac_name, '.')) {
-        //     AstPackage* package_node = onyx_ast_node_new(alloc, sizeof(AstPackage), Ast_Kind_Package);
-        //     package_node->package_name = package->name;
-        //     package_node->package = package;
-        //     package_node->type_node = builtin_package_id_type;
-        //     package_node->flags |= Ast_Flag_Comptime;
-
-        //     symbol_raw_introduce(context.global_scope, pac_name, pos, (AstNode *) package_node);
-        // }
-
+        // The builtin package is special. The 'builtin' symbol will be
+        // accessible even if you do not `use builtin`.
         if (!strcmp(pac_name, "builtin")) {
             AstPackage* package_node = onyx_ast_node_new(alloc, sizeof(AstPackage), Ast_Kind_Package);
             package_node->package_name = package->name;

--- a/core/alloc/arena.onyx
+++ b/core/alloc/arena.onyx
@@ -1,5 +1,7 @@
 package core.alloc.arena
 
+#import core
+
 // This allocator is mostly used for making many fixed-size
 // allocation (i.e. allocations that will not need to change
 // in size, such as game entities or position structs). The

--- a/core/alloc/arena.onyx
+++ b/core/alloc/arena.onyx
@@ -1,6 +1,6 @@
 package core.alloc.arena
 
-#import core
+use core
 
 // This allocator is mostly used for making many fixed-size
 // allocation (i.e. allocations that will not need to change

--- a/core/alloc/atomic.onyx
+++ b/core/alloc/atomic.onyx
@@ -6,7 +6,7 @@ package core.alloc.atomic
 // is not needed for the general purpose heap allocator,
 // as that already has a thread-safe implementation.
 
-use core {sync}
+#import core.sync
 
 AtomicAllocator :: struct {
     a: Allocator;

--- a/core/alloc/atomic.onyx
+++ b/core/alloc/atomic.onyx
@@ -6,7 +6,7 @@ package core.alloc.atomic
 // is not needed for the general purpose heap allocator,
 // as that already has a thread-safe implementation.
 
-#import core.sync
+use core.sync
 
 AtomicAllocator :: struct {
     a: Allocator;

--- a/core/alloc/fixed.onyx
+++ b/core/alloc/fixed.onyx
@@ -1,6 +1,6 @@
 package core.alloc.fixed
 
-#import core
+use core
 
 // This allocator is very simple and always returns the same pointer,
 // unless too much memory is asked for, in which case it returns null.

--- a/core/alloc/fixed.onyx
+++ b/core/alloc/fixed.onyx
@@ -1,5 +1,7 @@
 package core.alloc.fixed
 
+#import core
+
 // This allocator is very simple and always returns the same pointer,
 // unless too much memory is asked for, in which case it returns null.
 //

--- a/core/alloc/gc.onyx
+++ b/core/alloc/gc.onyx
@@ -16,7 +16,7 @@ package core.alloc.gc
 //       // Every allocation here will automatically be freed
 //   }
 
-#import core
+use core
 
 GCState :: struct {
     backing_allocator: Allocator;

--- a/core/alloc/gc.onyx
+++ b/core/alloc/gc.onyx
@@ -16,6 +16,8 @@ package core.alloc.gc
 //       // Every allocation here will automatically be freed
 //   }
 
+#import core
+
 GCState :: struct {
     backing_allocator: Allocator;
     first: &GCLink;

--- a/core/alloc/heap.onyx
+++ b/core/alloc/heap.onyx
@@ -1,7 +1,7 @@
 package core.alloc.heap
 
-#import runtime
-#import core
+use runtime
+use core
 
 
 // This is the implementation for the general purpose heap allocator.

--- a/core/alloc/heap.onyx
+++ b/core/alloc/heap.onyx
@@ -1,5 +1,8 @@
 package core.alloc.heap
 
+#import runtime
+#import core
+
 
 // This is the implementation for the general purpose heap allocator.
 // It is a simple bump allocator, with a free list. It is not very good

--- a/core/alloc/logging.onyx
+++ b/core/alloc/logging.onyx
@@ -4,7 +4,7 @@ package core.alloc.log
 // prints every allocation/deallocation made by that 
 // allocator.
 
-#import core
+use core
 
 #local
 Allocation_Action_Strings := str.[

--- a/core/alloc/logging.onyx
+++ b/core/alloc/logging.onyx
@@ -4,6 +4,8 @@ package core.alloc.log
 // prints every allocation/deallocation made by that 
 // allocator.
 
+#import core
+
 #local
 Allocation_Action_Strings := str.[
     " alloc",

--- a/core/alloc/pool.onyx
+++ b/core/alloc/pool.onyx
@@ -1,5 +1,7 @@
 package core.alloc.pool
 
+#import core
+
 // A pool allocator is an O(1) allocator that is capable of allocating and freeing.
 // It is able to do both in constant time because it maintains a linked list of all
 // the free elements in the pool. When an element is requested the first element of

--- a/core/alloc/pool.onyx
+++ b/core/alloc/pool.onyx
@@ -1,6 +1,6 @@
 package core.alloc.pool
 
-#import core
+use core
 
 // A pool allocator is an O(1) allocator that is capable of allocating and freeing.
 // It is able to do both in constant time because it maintains a linked list of all

--- a/core/alloc/ring.onyx
+++ b/core/alloc/ring.onyx
@@ -1,6 +1,6 @@
 package core.alloc.ring
 
-#import core
+use core
 
 // This allocator is great for temporary memory, such as returning
 // a pointer from a function, or storing a formatted string. The

--- a/core/alloc/ring.onyx
+++ b/core/alloc/ring.onyx
@@ -1,5 +1,7 @@
 package core.alloc.ring
 
+#import core
+
 // This allocator is great for temporary memory, such as returning
 // a pointer from a function, or storing a formatted string. The
 // memory allocated using this allocator does not need to be freed.

--- a/core/builtin.onyx
+++ b/core/builtin.onyx
@@ -1,6 +1,6 @@
 package builtin
 
-#import runtime
+use runtime
 
 //
 // Explanation of `package builtin`

--- a/core/builtin.onyx
+++ b/core/builtin.onyx
@@ -197,7 +197,7 @@ default_log_level :: (level: Log_Level) {
 
 #if runtime.runtime != .Custom {
     #local default_logger_proc :: (logger: &Default_Logger, level: Log_Level, msg: str, module: str) {
-        #import core;
+        use core;
 
         if level < logger.minimum_level do return;
 
@@ -265,8 +265,8 @@ cfree   :: (ptr: rawptr)            => raw_free(context.allocator, ptr);
 // This cannot be used in a custom runtime, as the other core
 // packages are not included.
 #if runtime.runtime != .Custom {
-    #import core
-    #import core.memory
+    use core
+    use core.memory
 
     new :: #match #local {}
 

--- a/core/builtin.onyx
+++ b/core/builtin.onyx
@@ -2,10 +2,6 @@ package builtin
 
 #import runtime
 
-#if #defined(package core) {
-    #import core
-}
-
 //
 // Explanation of `package builtin`
 //
@@ -201,6 +197,8 @@ default_log_level :: (level: Log_Level) {
 
 #if runtime.runtime != .Custom {
     #local default_logger_proc :: (logger: &Default_Logger, level: Log_Level, msg: str, module: str) {
+        #import core;
+
         if level < logger.minimum_level do return;
 
         if module {
@@ -267,12 +265,14 @@ cfree   :: (ptr: rawptr)            => raw_free(context.allocator, ptr);
 // This cannot be used in a custom runtime, as the other core
 // packages are not included.
 #if runtime.runtime != .Custom {
+    #import core
+    #import core.memory
+
     new :: #match #local {}
 
     #overload
     new :: ($T: type_expr, allocator := context.allocator) -> &T {
-        use package core.intrinsics.onyx { __initialize }
-        memory :: package core.memory
+        use core.intrinsics.onyx { __initialize }
 
         res := cast(&T) raw_alloc(allocator, sizeof T);
         memory.set(res, 0, sizeof T);
@@ -283,8 +283,7 @@ cfree   :: (ptr: rawptr)            => raw_free(context.allocator, ptr);
 
     #overload
     new :: (T: type_expr, allocator := context.allocator) -> rawptr {
-        memory :: package core.memory
-        type_info :: package runtime.info
+        type_info :: runtime.info
 
         info := type_info.get_type_info(T);
         size := type_info.size_of(T);
@@ -451,12 +450,12 @@ Code :: struct {_:i32;}
 // remove some confusion around the 3 different array types as dynamic arrays would clearly just be
 // normal structures. With the recent addition of macros and iterators, there really wouldn't be much
 // difference anyway.
-#if #defined((package core.map).Map) {
-    Map :: (package core.map).Map;
+#if #defined(core.map.Map) {
+    Map :: core.map.Map;
 }
 
-#if #defined((package core.set).Set) {
-    Set :: (package core.set).Set;
+#if #defined(core.set.Set) {
+    Set :: core.set.Set;
 }
 
 

--- a/core/builtin.onyx
+++ b/core/builtin.onyx
@@ -1,5 +1,11 @@
 package builtin
 
+#import runtime
+
+#if #defined(package core) {
+    #import core
+}
+
 //
 // Explanation of `package builtin`
 //

--- a/core/container/array.onyx
+++ b/core/container/array.onyx
@@ -1,6 +1,6 @@
 package core.array
 
-#import core
+use core
 
 // [..] T == Array(T)
 //   where

--- a/core/container/array.onyx
+++ b/core/container/array.onyx
@@ -1,5 +1,7 @@
 package core.array
 
+#import core
+
 // [..] T == Array(T)
 //   where
 // Array :: struct (T: type_expr) {
@@ -31,12 +33,12 @@ make :: (base: [] $T, allocator := context.allocator) -> [..] T {
 
 #overload
 __make_overload :: macro (_: &[..] $T, allocator := context.allocator) -> [..] T {
-    return core.array.make(T, allocator=allocator);
+    return #this_package.make(T, allocator=allocator);
 }
 
 #overload
 __make_overload :: macro (_: &[..] $T, capacity: u32, allocator := context.allocator) -> [..] T {
-    return core.array.make(T, capacity, allocator);
+    return #this_package.make(T, capacity, allocator);
 }
 
 init :: (arr: &[..] $T, capacity := 4, allocator := context.allocator) {
@@ -56,7 +58,7 @@ free :: (arr: &[..] $T) {
 
 #overload
 builtin.delete :: macro (x: &[..] $T) {
-    core.array.free(x);
+    #this_package.free(x);
 }
 
 copy :: #match #locked {
@@ -114,7 +116,7 @@ push :: (arr: &[..] $T, x: T) -> bool {
 }
 
 // Semi-useful shortcut for adding something to an array.
-#operator << macro (arr: [..] $T, v: T) do core.array.push(&arr, v);
+#operator << macro (arr: [..] $T, v: T) do #this_package.push(&arr, v);
 
 insert :: #match #local {}
 

--- a/core/container/avl_tree.onyx
+++ b/core/container/avl_tree.onyx
@@ -1,7 +1,7 @@
 package core.avl_tree
 
-#import core
-#import core.math
+use core
+use core.math
 
 AVL_Tree :: struct (T: type_expr) {
     data: T;

--- a/core/container/avl_tree.onyx
+++ b/core/container/avl_tree.onyx
@@ -1,6 +1,7 @@
 package core.avl_tree
 
-use core {math}
+#import core
+#import core.math
 
 AVL_Tree :: struct (T: type_expr) {
     data: T;

--- a/core/container/bucket_array.onyx
+++ b/core/container/bucket_array.onyx
@@ -2,9 +2,9 @@
 
 package core.bucket_array
 
-#import core
-#import core.array
-#import core.iter
+use core
+use core.array
+use core.iter
 
 Bucket_Array :: struct (T: type_expr) {
     allocator : Allocator;

--- a/core/container/bucket_array.onyx
+++ b/core/container/bucket_array.onyx
@@ -2,7 +2,9 @@
 
 package core.bucket_array
 
-use core {array, iter}
+#import core
+#import core.array
+#import core.iter
 
 Bucket_Array :: struct (T: type_expr) {
     allocator : Allocator;
@@ -83,7 +85,7 @@ push :: (use b: &Bucket_Array($T), elem: T) -> bool {
     }
 }
 
-#operator << macro (b: Bucket_Array($T), elem: T) do core.bucket_array.push(&b, elem);
+#operator << macro (b: Bucket_Array($T), elem: T) do #this_package.push(&b, elem);
 
 pop :: (use b: &Bucket_Array($T)) {
     last_bucket := &buckets[buckets.count - 1];

--- a/core/container/heap.onyx
+++ b/core/container/heap.onyx
@@ -1,6 +1,6 @@
 package core.heap
 
-use core {array}
+#import core.array
 
 Heap :: struct (T: type_expr) {
     data: [..] T;
@@ -23,7 +23,7 @@ insert :: (use heap: &Heap, v: heap.T) {
     shift_up(heap, data.count - 1);
 }
 
-#operator << macro (heap: Heap($T), v: T) do core.heap.insert(&heap, v);
+#operator << macro (heap: Heap($T), v: T) do #this_package.insert(&heap, v);
 
 remove_top :: (use heap: &Heap) -> heap.T {
     x := data[0];

--- a/core/container/heap.onyx
+++ b/core/container/heap.onyx
@@ -1,6 +1,6 @@
 package core.heap
 
-#import core.array
+use core.array
 
 Heap :: struct (T: type_expr) {
     data: [..] T;

--- a/core/container/iter.onyx
+++ b/core/container/iter.onyx
@@ -1,10 +1,10 @@
 package core.iter
 
-#import core
-#import core.memory
-#import core.alloc
-#import core.array
-#import runtime
+use core
+use core.memory
+use core.alloc
+use core.array
+use runtime
 
 use core {Pair}
 use core.intrinsics.types {type_is_struct}

--- a/core/container/iter.onyx
+++ b/core/container/iter.onyx
@@ -1,6 +1,12 @@
 package core.iter
 
-use core {memory, alloc, array, Pair}
+#import core
+#import core.memory
+#import core.alloc
+#import core.array
+#import runtime
+
+use core {Pair}
 use core.intrinsics.types {type_is_struct}
 
 

--- a/core/container/list.onyx
+++ b/core/container/list.onyx
@@ -1,6 +1,6 @@
 package core.list
 
-#import core
+use core
 
 ListElem :: struct (T: type_expr) {
     next: &ListElem(T) = null;

--- a/core/container/list.onyx
+++ b/core/container/list.onyx
@@ -1,5 +1,7 @@
 package core.list
 
+#import core
+
 ListElem :: struct (T: type_expr) {
     next: &ListElem(T) = null;
     prev: &ListElem(T) = null;

--- a/core/container/map.onyx
+++ b/core/container/map.onyx
@@ -1,11 +1,11 @@
 package core.map
 
-#import core
-#import core.array
-#import core.hash
-#import core.memory
-#import core.math
-#import core.conv
+use core
+use core.array
+use core.hash
+use core.memory
+use core.math
+use core.conv
 
 use core {Optional}
 use core.intrinsics.onyx { __initialize }

--- a/core/container/map.onyx
+++ b/core/container/map.onyx
@@ -1,6 +1,13 @@
 package core.map
 
-use core {array, hash, memory, math, conv, Optional}
+#import core
+#import core.array
+#import core.hash
+#import core.memory
+#import core.math
+#import core.conv
+
+use core {Optional}
 use core.intrinsics.onyx { __initialize }
 
 //

--- a/core/container/pair.onyx
+++ b/core/container/pair.onyx
@@ -1,5 +1,6 @@
 package core
 
+
 //
 // A `Pair` represents a pair of values of heterogenous types.
 // This structure does not do much on its own; however, it
@@ -24,7 +25,7 @@ Pair :: struct (First_Type: type_expr, Second_Type: type_expr) {
 }
 
 #overload
-core.hash.hash :: (p: Pair($First_Type/hash.Hashable, $Second_Type/hash.Hashable)) => {
+hash.hash :: (p: Pair($First_Type/hash.Hashable, $Second_Type/hash.Hashable)) => {
     h := 7;
     h += h << 5 + hash.hash(p.first);
     h += h << 5 + hash.hash(p.second);

--- a/core/container/result.onyx
+++ b/core/container/result.onyx
@@ -8,8 +8,8 @@ package core
 // helper methods that make it easier to work with Results.
 //
 
-#import core
-#import core.conv
+use core
+use core.conv
 
 use core {Optional}
 

--- a/core/container/result.onyx
+++ b/core/container/result.onyx
@@ -8,8 +8,10 @@ package core
 // helper methods that make it easier to work with Results.
 //
 
+#import core
+#import core.conv
 
-use core {Optional, conv}
+use core {Optional}
 
 #doc """
     Result(T, E) is a structure that represents either an Ok value

--- a/core/container/set.onyx
+++ b/core/container/set.onyx
@@ -1,6 +1,12 @@
 package core.set
 
-use core {array, hash, memory, math, Optional}
+#import core
+#import core.array
+#import core.hash
+#import core.memory
+#import core.math
+
+use core {Optional}
 
 #local SetValue :: interface (t: $T) {
     { hash.hash(t) } -> u32;
@@ -43,7 +49,7 @@ make :: ($T: type_expr, default := T.{}, allocator := context.allocator) -> Set(
 }
 
 #overload
-builtin.__make_overload :: macro (x: &Set, allocator: Allocator) => core.set.make(x.Elem_Type, allocator = allocator);
+builtin.__make_overload :: macro (x: &Set, allocator: Allocator) => #this_package.make(x.Elem_Type, allocator = allocator);
 
 init :: (set: &Set($T), default := T.{}, allocator := context.allocator) {
     set.allocator = allocator;
@@ -61,7 +67,7 @@ free :: (use set: &Set) {
 }
 
 #overload
-builtin.delete :: core.set.free
+builtin.delete :: #this_package.free
 
 insert :: (use set: &Set, value: set.Elem_Type) {
     if hashes.data == null do init(set);
@@ -75,7 +81,7 @@ insert :: (use set: &Set, value: set.Elem_Type) {
     if full(set) do grow(set);
 }
 
-#operator << macro (set: Set($T), value: T) do core.set.insert(&set, value);
+#operator << macro (set: Set($T), value: T) do #this_package.insert(&set, value);
 
 has :: (use set: &Set, value: set.Elem_Type) -> bool {
     lr := lookup(set, value);

--- a/core/container/set.onyx
+++ b/core/container/set.onyx
@@ -1,10 +1,10 @@
 package core.set
 
-#import core
-#import core.array
-#import core.hash
-#import core.memory
-#import core.math
+use core
+use core.array
+use core.hash
+use core.memory
+use core.math
 
 use core {Optional}
 

--- a/core/conv/conv.onyx
+++ b/core/conv/conv.onyx
@@ -2,7 +2,8 @@ package core.conv
 
 Enable_Custom_Formatters :: true
 
-use core {string, math}
+#import core.string
+#import core.math
 
 //
 // Converts a string into an integer. Works with positive and
@@ -19,8 +20,6 @@ str_to_i64 :: macro (s: str, base: u32 = 10) -> i64 {
 
 #overload
 str_to_i64 :: (s: &str, base: u32 = 10) -> i64 {
-    use package core
-
     string.strip_leading_whitespace(s);
 
     value: i64 = 0;
@@ -79,8 +78,6 @@ str_to_f64 :: macro (s: str) -> f64 {
 
 #overload
 str_to_f64 :: (s: &str) -> f64 {
-    use package core
-
     string.strip_leading_whitespace(s);
 
     sign := parse_sign(s);

--- a/core/conv/conv.onyx
+++ b/core/conv/conv.onyx
@@ -2,8 +2,8 @@ package core.conv
 
 Enable_Custom_Formatters :: true
 
-#import core.string
-#import core.math
+use core.string
+use core.math
 
 //
 // Converts a string into an integer. Works with positive and

--- a/core/conv/format.onyx
+++ b/core/conv/format.onyx
@@ -21,7 +21,7 @@ custom_formatters_initialized :: #init () {
     map.init(&custom_parsers,    default=null_proc);
 
     #if Enable_Custom_Formatters {
-        use package runtime.info;
+        use runtime.info;
 
         for type_idx: type_table.count {
             type := type_table[type_idx];

--- a/core/conv/format.onyx
+++ b/core/conv/format.onyx
@@ -1,6 +1,11 @@
 package core.conv
 
-use core {map, string, array, math}
+#import core.map
+#import core.string
+#import core.array
+#import core.math
+#import core.io
+#import runtime
 
 #package {
     custom_formatters: Map(type_expr, #type (&Format_Output, &Format, rawptr) -> void);
@@ -401,8 +406,7 @@ format_va :: (output: &Format_Output, format: str, va: [] any) -> str {
 // If a custom formatter is specified for the type, that is used instead.
 // This procedure is generally not used directly; instead, through format or format_va.
 format_any :: (output: &Format_Output, formatting: &Format, v: any) {
-    use package runtime.info
-    array :: package core.array;
+    use runtime.info;
 
     //
     // Dereference the any if the '*' format specifier was given.
@@ -521,8 +525,6 @@ format_any :: (output: &Format_Output, formatting: &Format, v: any) {
 
         case type_expr {
             value := *(cast(&type_expr) v.data);
-
-            io :: package core.io
 
             buf : [256] u8;          
 

--- a/core/conv/format.onyx
+++ b/core/conv/format.onyx
@@ -1,11 +1,11 @@
 package core.conv
 
-#import core.map
-#import core.string
-#import core.array
-#import core.math
-#import core.io
-#import runtime
+use core.map
+use core.string
+use core.array
+use core.math
+use core.io
+use runtime
 
 #package {
     custom_formatters: Map(type_expr, #type (&Format_Output, &Format, rawptr) -> void);
@@ -21,7 +21,7 @@ custom_formatters_initialized :: #init () {
     map.init(&custom_parsers,    default=null_proc);
 
     #if Enable_Custom_Formatters {
-        use runtime.info;
+        use runtime.info {*};
 
         for type_idx: type_table.count {
             type := type_table[type_idx];
@@ -406,7 +406,7 @@ format_va :: (output: &Format_Output, format: str, va: [] any) -> str {
 // If a custom formatter is specified for the type, that is used instead.
 // This procedure is generally not used directly; instead, through format or format_va.
 format_any :: (output: &Format_Output, formatting: &Format, v: any) {
-    use runtime.info;
+    use runtime.info {*};
 
     //
     // Dereference the any if the '*' format specifier was given.

--- a/core/conv/parse.onyx
+++ b/core/conv/parse.onyx
@@ -1,6 +1,10 @@
 package core.conv
 
-use core {map, string, array, math}
+#import core.map
+#import core.string
+#import core.array
+#import core.math
+#import runtime
 
 //
 // Parses many different types from a string into a value.

--- a/core/conv/parse.onyx
+++ b/core/conv/parse.onyx
@@ -22,7 +22,7 @@ parse_any :: (target: rawptr, data_type: type_expr, to_parse: str, string_alloca
         return custom_parsers[data_type](target, to_parse, string_allocator);
     }
 
-    use runtime.info;
+    use runtime.info {*};
     info := get_type_info(data_type);
 
     switch data_type {

--- a/core/conv/parse.onyx
+++ b/core/conv/parse.onyx
@@ -1,10 +1,10 @@
 package core.conv
 
-#import core.map
-#import core.string
-#import core.array
-#import core.math
-#import runtime
+use core.map
+use core.string
+use core.array
+use core.math
+use runtime
 
 //
 // Parses many different types from a string into a value.

--- a/core/encoding/base64.onyx
+++ b/core/encoding/base64.onyx
@@ -1,6 +1,6 @@
 package core.encoding.base64
 
-use core {array}
+#import core.array
 
 //
 // A simple Base64 encoding and decoding library. Currently

--- a/core/encoding/base64.onyx
+++ b/core/encoding/base64.onyx
@@ -1,6 +1,6 @@
 package core.encoding.base64
 
-#import core.array
+use core.array
 
 //
 // A simple Base64 encoding and decoding library. Currently

--- a/core/encoding/csv.onyx
+++ b/core/encoding/csv.onyx
@@ -9,14 +9,14 @@ package core.encoding.csv
 // it ergonomic to work with.
 //
 
-#import core
-#import core.string
-#import core.array
-#import core.iter
-#import core.conv
-#import core.io
-#import core.test
-#import runtime
+use core
+use core.string
+use core.array
+use core.iter
+use core.conv
+use core.io
+use core.test
+use runtime
 
 use core.misc {any_as}
 use runtime.info {

--- a/core/encoding/csv.onyx
+++ b/core/encoding/csv.onyx
@@ -9,7 +9,15 @@ package core.encoding.csv
 // it ergonomic to work with.
 //
 
-use core {string, array, iter, conv, io}
+#import core
+#import core.string
+#import core.array
+#import core.iter
+#import core.conv
+#import core.io
+#import core.test
+#import runtime
+
 use core.misc {any_as}
 use runtime.info {
     get_type_info,
@@ -162,8 +170,8 @@ CSV_Column :: struct {
 // Example and test case
 //
 
-@core.test.test.{"CSV Test"}
-(t: &core.test.T) {
+@test.test.{"CSV Test"}
+(t: &test.T) {
     data := """first,second,third
 1,test 1,1.2
 2,test 2,2.4

--- a/core/encoding/ini.onyx
+++ b/core/encoding/ini.onyx
@@ -32,10 +32,10 @@ package core.encoding.ini
 //     display_name=Player
 //
 
-#import core.alloc
-#import core.conv
-#import core.string
-#import core.io
+use core.alloc
+use core.conv
+use core.string
+use core.io
 
 use core { aprintf }
 use core.intrinsics.types { type_is_struct }

--- a/core/encoding/ini.onyx
+++ b/core/encoding/ini.onyx
@@ -32,13 +32,13 @@ package core.encoding.ini
 //     display_name=Player
 //
 
-use core {
-    alloc, conv, string, io,
-    aprintf
-}
-use core.intrinsics.types {
-    type_is_struct
-}
+#import core.alloc
+#import core.conv
+#import core.string
+#import core.io
+
+use core { aprintf }
+use core.intrinsics.types { type_is_struct }
 
 //
 // Represents if the parsing was successful or encountered an error.

--- a/core/encoding/osad.onyx
+++ b/core/encoding/osad.onyx
@@ -1,10 +1,10 @@
 package core.encoding.osad
 
-#import core.io
-#import core.string
-#import core.array
-#import core.memory
-#import runtime
+use core.io
+use core.string
+use core.array
+use core.memory
+use runtime
 
 use runtime {
     type_info :: info

--- a/core/encoding/osad.onyx
+++ b/core/encoding/osad.onyx
@@ -1,7 +1,11 @@
 package core.encoding.osad
 
+#import core.io
+#import core.string
+#import core.array
+#import core.memory
+#import runtime
 
-use core {io, string, array, memory}
 use runtime {
     type_info :: info
 }

--- a/core/encoding/utf8.onyx
+++ b/core/encoding/utf8.onyx
@@ -1,6 +1,8 @@
 package core.encoding.utf8
 
-use core {string, array, iter}
+#import core.string
+#import core.array
+#import core.iter
 
 rune :: i32
 

--- a/core/encoding/utf8.onyx
+++ b/core/encoding/utf8.onyx
@@ -1,8 +1,8 @@
 package core.encoding.utf8
 
-#import core.string
-#import core.array
-#import core.iter
+use core.string
+use core.array
+use core.iter
 
 rune :: i32
 

--- a/core/intrinsics/atomics.onyx
+++ b/core/intrinsics/atomics.onyx
@@ -1,7 +1,7 @@
 package core.intrinsics.atomics
 
 #local {
-    #import runtime
+    use runtime
 
     #if !runtime.Multi_Threading_Enabled {
         #error "Multi-threading is not enabled so you cannot include the 'core.intrinsics.atomics' package."

--- a/core/intrinsics/atomics.onyx
+++ b/core/intrinsics/atomics.onyx
@@ -1,7 +1,7 @@
 package core.intrinsics.atomics
 
 #local {
-    runtime :: package runtime
+    #import runtime
 
     #if !runtime.Multi_Threading_Enabled {
         #error "Multi-threading is not enabled so you cannot include the 'core.intrinsics.atomics' package."

--- a/core/io/binary.onyx
+++ b/core/io/binary.onyx
@@ -1,6 +1,7 @@
 package core.io
 
-use core
+#import core.memory
+
 
 BinaryWriter :: struct {
     stream: &Stream;

--- a/core/io/binary.onyx
+++ b/core/io/binary.onyx
@@ -1,6 +1,6 @@
 package core.io
 
-#import core.memory
+use core.memory
 
 
 BinaryWriter :: struct {

--- a/core/io/reader.onyx
+++ b/core/io/reader.onyx
@@ -8,7 +8,10 @@ package core.io
 // reader could not, like 'read the next line',
 // or 'read until a period'.
 
-use core {memory, math, array, iter}
+#import core.memory
+#import core.math
+#import core.array
+#import core.iter
 
 Reader :: struct {
     stream: &Stream;

--- a/core/io/reader.onyx
+++ b/core/io/reader.onyx
@@ -8,10 +8,10 @@ package core.io
 // reader could not, like 'read the next line',
 // or 'read until a period'.
 
-#import core.memory
-#import core.math
-#import core.array
-#import core.iter
+use core.memory
+use core.math
+use core.array
+use core.iter
 
 Reader :: struct {
     stream: &Stream;

--- a/core/io/stdio.onyx
+++ b/core/io/stdio.onyx
@@ -6,6 +6,8 @@
 // in anyway.
 package core
 
+#import runtime
+
 
 //
 // Ensure this file did not get included in a custom runtime, as it is

--- a/core/io/stdio.onyx
+++ b/core/io/stdio.onyx
@@ -1,8 +1,8 @@
 // Currently, these symbols are dumped in the 'core' namespace, which means
-// most programs that just 'use package core' can access all of them, which
+// most programs that just 'use core' can access all of them, which
 // is convenient; However, it doesn't hurt to wonder if they should be the
 // 'core.io' package so these would become like 'io.printf(...)'. Of course,
-// you could always still do 'use package core.io', which would bring these
+// you could always still do 'use core.io', which would bring these
 // in anyway.
 package core
 

--- a/core/io/stdio.onyx
+++ b/core/io/stdio.onyx
@@ -6,7 +6,7 @@
 // in anyway.
 package core
 
-#import runtime
+use runtime
 
 
 //

--- a/core/io/stream.onyx
+++ b/core/io/stream.onyx
@@ -1,5 +1,6 @@
 package core.io
 
+#import core
 use core
 
 Stream :: struct {

--- a/core/io/stream.onyx
+++ b/core/io/stream.onyx
@@ -1,7 +1,7 @@
 package core.io
 
-#import core
 use core
+use core {*}
 
 Stream :: struct {
     use vtable : &Stream_Vtable;

--- a/core/io/writer.onyx
+++ b/core/io/writer.onyx
@@ -1,8 +1,8 @@
 package core.io
 
-#import core.conv
-#import core.string
-#import core.memory
+use core.conv
+use core.string
+use core.memory
 
 // io.Writer is a buffered-writer. The important thing to not forget
 // when using io.Writer is that it has to be flushed when you are done

--- a/core/io/writer.onyx
+++ b/core/io/writer.onyx
@@ -1,6 +1,8 @@
 package core.io
 
-use core {conv, string, memory}
+#import core.conv
+#import core.string
+#import core.memory
 
 // io.Writer is a buffered-writer. The important thing to not forget
 // when using io.Writer is that it has to be flushed when you are done

--- a/core/math/math.onyx
+++ b/core/math/math.onyx
@@ -1,7 +1,7 @@
 package core.math
 
-#import core
-#import core.intrinsics.wasm
+use core
+use core.intrinsics.wasm
 
 // Things that are useful in any math library:
 //  - Trigonometry

--- a/core/math/math.onyx
+++ b/core/math/math.onyx
@@ -1,6 +1,7 @@
 package core.math
 
-use core.intrinsics {wasm}
+#import core
+#import core.intrinsics.wasm
 
 // Things that are useful in any math library:
 //  - Trigonometry

--- a/core/memory/memory.onyx
+++ b/core/memory/memory.onyx
@@ -69,7 +69,7 @@ align :: (size: u64, align: u64) -> u64 {
 //
 // Allows for make([] i32).
 #overload
-builtin.__make_overload :: macro (_: &[] $T, count: u32, allocator := context.allocator) -> [] T {
+__make_overload :: macro (_: &[] $T, count: u32, allocator := context.allocator) -> [] T {
     ret := #this_package.make_slice(T, count, allocator);
     #this_package.set(ret.data, 0, sizeof T * count);
     return ret;

--- a/core/memory/memory.onyx
+++ b/core/memory/memory.onyx
@@ -1,5 +1,7 @@
 package core.memory
 
+use core
+
 //
 // Re-exports the memory_copy intrinsics. Behaves like memmove() in C.
 copy :: core.intrinsics.wasm.memory_copy

--- a/core/misc/any_utils.onyx
+++ b/core/misc/any_utils.onyx
@@ -1,9 +1,9 @@
 package core.misc
 
-#import runtime
-#import core.iter
-#import core.array
-#import core.string
+use runtime
+use core.iter
+use core.array
+use core.string
 
 use runtime.info {
     get_type_info,

--- a/core/misc/any_utils.onyx
+++ b/core/misc/any_utils.onyx
@@ -1,5 +1,10 @@
 package core.misc
 
+#import runtime
+#import core.iter
+#import core.array
+#import core.string
+
 use runtime.info {
     get_type_info,
     Type_Info_Pointer,
@@ -10,8 +15,6 @@ use runtime.info {
 
     get_struct_member
 }
-
-use core { iter, array, string }
 
 // Either to_any or as_any will work. I prefer `as_any` because
 // much of the rest of the standard library uses `as_...` for

--- a/core/misc/any_utils.onyx
+++ b/core/misc/any_utils.onyx
@@ -127,7 +127,7 @@ any_to_map :: (v: any) -> (Map(str, any), success: bool) {
 any_iter :: (arr: any) -> Iterator(any) {
     base_ptr, elem_type, count := any_as_array(arr);
     if count == 0 {
-        return .{ null, ((_) => any.{}, false) };
+        return .{ null, ((_: rawptr) => any.{}, false) };
     }
 
     return iter.generator(

--- a/core/misc/arg_parse.onyx
+++ b/core/misc/arg_parse.onyx
@@ -22,7 +22,13 @@ package core.arg_parse
 // false and are true if one or more of the option values are present.
 //
 
-use core
+#import core
+#import core.iter
+#import core.conv
+#import core.string
+#import runtime
+
+use core {printf}
 
 arg_parse :: (c_args: [] cstr, output: any) -> bool {
     arg_iter := iter.as_iter(c_args)

--- a/core/misc/arg_parse.onyx
+++ b/core/misc/arg_parse.onyx
@@ -22,20 +22,18 @@ package core.arg_parse
 // false and are true if one or more of the option values are present.
 //
 
-#import core
-#import core.iter
-#import core.conv
-#import core.string
-#import runtime
-
-use core {printf}
+use core {package, printf}
+use core.iter
+use core.conv
+use core.string
+use runtime
 
 arg_parse :: (c_args: [] cstr, output: any) -> bool {
     arg_iter := iter.as_iter(c_args)
              |> iter.map(string.from_cstr);
     defer arg_iter.close(arg_iter.data);
 
-    use runtime.info;
+    use runtime.info {*};
 
     ptr_type := cast(&Type_Info_Pointer) get_type_info(output.type);
     if ptr_type.kind != .Pointer do return false;

--- a/core/net/net.onyx
+++ b/core/net/net.onyx
@@ -4,6 +4,9 @@ package core.net
     #error "Cannot include this file. Platform not supported.";
 }
 
+#import core
+#import runtime
+
 use core
 
 Socket :: struct {

--- a/core/net/net.onyx
+++ b/core/net/net.onyx
@@ -4,10 +4,8 @@ package core.net
     #error "Cannot include this file. Platform not supported.";
 }
 
-#import core
-#import runtime
-
-use core
+use core {*}
+use runtime
 
 Socket :: struct {
     Handle :: #distinct i32

--- a/core/net/tcp.onyx
+++ b/core/net/tcp.onyx
@@ -4,7 +4,14 @@ package core.net
     #error "Cannot include this file. Platform not supported.";
 }
 
-use core {sync, thread, array, memory, alloc, os, iter}
+#import core.sync
+#import core.thread
+#import core.array
+#import core.memory
+#import core.alloc
+#import core.os
+#import core.iter
+#import runtime
 
 #if !runtime.Multi_Threading_Enabled {
     #error "Expected multi-threading to be enabled for TCP server.";
@@ -365,7 +372,7 @@ wait_to_get_client_messages :: (use server: &TCP_Server) -> [] &TCP_Server.Clien
         }
     }
 
-    status_buffer := alloc.array_from_stack(core.net.Socket_Poll_Status, client_count);
+    status_buffer := alloc.array_from_stack(Socket_Poll_Status, client_count);
     socket_poll_all(cast([] &Socket) active_clients, pulse_time_ms, status_buffer);
 
     recv_clients: [..] &TCP_Server.Client;

--- a/core/net/tcp.onyx
+++ b/core/net/tcp.onyx
@@ -4,14 +4,14 @@ package core.net
     #error "Cannot include this file. Platform not supported.";
 }
 
-#import core.sync
-#import core.thread
-#import core.array
-#import core.memory
-#import core.alloc
-#import core.os
-#import core.iter
-#import runtime
+use core.sync
+use core.thread
+use core.array
+use core.memory
+use core.alloc
+use core.os
+use core.iter
+use runtime
 
 #if !runtime.Multi_Threading_Enabled {
     #error "Expected multi-threading to be enabled for TCP server.";

--- a/core/onyx/cbindgen.onyx
+++ b/core/onyx/cbindgen.onyx
@@ -41,8 +41,8 @@ package cbindgen
 
 #if #defined (runtime.Generated_Foreign_Info) {
 
-#import core
-#import runtime
+use core
+use runtime
 
 #if runtime.compiler_os == .Linux {
     #if #defined (runtime.vars.CC) {

--- a/core/onyx/cbindgen.onyx
+++ b/core/onyx/cbindgen.onyx
@@ -41,6 +41,9 @@ package cbindgen
 
 #if #defined (runtime.Generated_Foreign_Info) {
 
+#import core
+#import runtime
+
 #if runtime.compiler_os == .Linux {
     #if #defined (runtime.vars.CC) {
         Linux_Compiler :: runtime.vars.CC    

--- a/core/onyx/cptr.onyx
+++ b/core/onyx/cptr.onyx
@@ -70,7 +70,7 @@ cptr :: struct (T: type_expr) {
         // to the same idea as 'null' in Onyx.
         if this.data == 0 do return null;
 
-        wasm :: package core.intrinsics.wasm
+        #import core.intrinsics.wasm
         // Using 1 instead of 0 because a null pointer (0) converts
         // to the memory address 0, not the base address for the WASM
         // memory.

--- a/core/onyx/cptr.onyx
+++ b/core/onyx/cptr.onyx
@@ -70,7 +70,7 @@ cptr :: struct (T: type_expr) {
         // to the same idea as 'null' in Onyx.
         if this.data == 0 do return null;
 
-        #import core.intrinsics.wasm
+        use core.intrinsics.wasm
         // Using 1 instead of 0 because a null pointer (0) converts
         // to the memory address 0, not the base address for the WASM
         // memory.

--- a/core/os/dir.onyx
+++ b/core/os/dir.onyx
@@ -4,8 +4,8 @@ package core.os
     #error "Cannot include this file. Platform not supported.";
 }
 
-#import core.string
-#import runtime
+use core.string
+use runtime
 
 #local fs :: runtime.platform
 

--- a/core/os/dir.onyx
+++ b/core/os/dir.onyx
@@ -4,7 +4,9 @@ package core.os
     #error "Cannot include this file. Platform not supported.";
 }
 
-use core {string}
+#import core.string
+#import runtime
+
 #local fs :: runtime.platform
 
 Directory :: fs.DirectoryData;

--- a/core/os/file.onyx
+++ b/core/os/file.onyx
@@ -4,10 +4,8 @@ package core.os
     #error "Cannot include this file. Platform not supported.";
 }
 
-#import core
-#import runtime
-
-use core
+use core {*}
+use runtime
 
 
 #local fs :: runtime.platform

--- a/core/os/file.onyx
+++ b/core/os/file.onyx
@@ -4,7 +4,11 @@ package core.os
     #error "Cannot include this file. Platform not supported.";
 }
 
+#import core
+#import runtime
+
 use core
+
 #local fs :: package runtime.platform
 
 

--- a/core/os/file.onyx
+++ b/core/os/file.onyx
@@ -9,7 +9,8 @@ package core.os
 
 use core
 
-#local fs :: package runtime.platform
+
+#local fs :: runtime.platform
 
 
 FileError :: enum {

--- a/core/os/os.onyx
+++ b/core/os/os.onyx
@@ -1,6 +1,6 @@
 package core.os
 
-#import runtime
+use runtime
 
 #if !runtime.platform.Supports_Os {
     #error "Cannot include this file. Platform not supported.";

--- a/core/os/os.onyx
+++ b/core/os/os.onyx
@@ -1,6 +1,6 @@
 package core.os
 
-use core {string}
+#import runtime
 
 #if !runtime.platform.Supports_Os {
     #error "Cannot include this file. Platform not supported.";

--- a/core/os/process.onyx
+++ b/core/os/process.onyx
@@ -4,7 +4,9 @@ package core.os
     #error "Cannot include this file. Platform not supported.";
 }
 
-use core {io}
+#import core.io
+#import runtime
+
 use runtime.platform {
     __process_spawn,
     __process_destroy,

--- a/core/os/process.onyx
+++ b/core/os/process.onyx
@@ -4,8 +4,8 @@ package core.os
     #error "Cannot include this file. Platform not supported.";
 }
 
-#import core.io
-#import runtime
+use core.io
+use runtime
 
 use runtime.platform {
     __process_spawn,

--- a/core/random/random.onyx
+++ b/core/random/random.onyx
@@ -1,5 +1,7 @@
 package core.random
 
+#import core
+
 //
 // The state of a random number generator.
 Random :: struct {
@@ -52,7 +54,7 @@ Random :: struct {
     // Returns a random string of length `bytes_long`. If `alpha_numeric` is
     // true, then the string will only consist of alpha-numeric characters.
     string :: (self: &Random, bytes_long: u32, alpha_numeric := false, allocator := context.allocator) -> str {
-        memory :: package core.memory
+        #import core.memory
 
         s := memory.make_slice(u8, bytes_long, allocator=allocator);
         for& s {

--- a/core/random/random.onyx
+++ b/core/random/random.onyx
@@ -1,6 +1,6 @@
 package core.random
 
-#import core
+use core
 
 //
 // The state of a random number generator.
@@ -54,7 +54,7 @@ Random :: struct {
     // Returns a random string of length `bytes_long`. If `alpha_numeric` is
     // true, then the string will only consist of alpha-numeric characters.
     string :: (self: &Random, bytes_long: u32, alpha_numeric := false, allocator := context.allocator) -> str {
-        #import core.memory
+        use core.memory
 
         s := memory.make_slice(u8, bytes_long, allocator=allocator);
         for& s {

--- a/core/runtime/common.onyx
+++ b/core/runtime/common.onyx
@@ -1,5 +1,7 @@
 package runtime
 
+#import core
+
 use core
 use core.intrinsics.onyx { __initialize }
 use platform { __output_string }

--- a/core/runtime/common.onyx
+++ b/core/runtime/common.onyx
@@ -1,10 +1,8 @@
 package runtime
 
-#import core
-
-use core
+use core {package, *}
 use core.intrinsics.onyx { __initialize }
-use platform { __output_string }
+use runtime.platform { __output_string }
 
 //
 // Export the __start function from the platform layer.

--- a/core/runtime/info/helper.onyx
+++ b/core/runtime/info/helper.onyx
@@ -1,7 +1,7 @@
 package runtime.info
 
-#import core
-#import core.io
+use core
+use core.io
 
 write_type_name :: (writer: &io.Writer, t: type_expr) {
     info := get_type_info(t);
@@ -331,7 +331,7 @@ populate_struct_vtable :: (table: &$Table_Type, struct_type: type_expr, safe := 
 }
 
 for_all_types :: macro (body: Code) {
-    #import runtime
+    use runtime
 
     for runtime.info.type_table.count {
         type_info := runtime.info.type_table[it];

--- a/core/runtime/info/helper.onyx
+++ b/core/runtime/info/helper.onyx
@@ -331,8 +331,10 @@ populate_struct_vtable :: (table: &$Table_Type, struct_type: type_expr, safe := 
 }
 
 for_all_types :: macro (body: Code) {
+    #import runtime
+
     for runtime.info.type_table.count {
-        type_info := (package runtime.info).type_table[it];
+        type_info := runtime.info.type_table[it];
         type_idx  : type_expr = ~~ it;
 
         #unquote body;

--- a/core/runtime/info/helper.onyx
+++ b/core/runtime/info/helper.onyx
@@ -1,6 +1,7 @@
 package runtime.info
 
-use core {io}
+#import core
+#import core.io
 
 write_type_name :: (writer: &io.Writer, t: type_expr) {
     info := get_type_info(t);

--- a/core/runtime/info/proc_tags.onyx
+++ b/core/runtime/info/proc_tags.onyx
@@ -1,7 +1,7 @@
 
 package runtime.info
 
-#import core.array
+use core.array
 
 tagged_procedures: [] &Tagged_Procedure
 

--- a/core/runtime/info/proc_tags.onyx
+++ b/core/runtime/info/proc_tags.onyx
@@ -1,7 +1,7 @@
 
 package runtime.info
 
-use core {array}
+#import core.array
 
 tagged_procedures: [] &Tagged_Procedure
 

--- a/core/runtime/platform/js/platform.onyx
+++ b/core/runtime/platform/js/platform.onyx
@@ -1,9 +1,7 @@
 package runtime.platform
 
-#import core
-#import runtime
-
 use core
+use runtime
 use runtime {
     __runtime_initialize,
     Multi_Threading_Enabled,

--- a/core/runtime/platform/js/platform.onyx
+++ b/core/runtime/platform/js/platform.onyx
@@ -1,5 +1,8 @@
 package runtime.platform
 
+#import core
+#import runtime
+
 use core
 use runtime {
     __runtime_initialize,

--- a/core/runtime/platform/onyx/fs.onyx
+++ b/core/runtime/platform/onyx/fs.onyx
@@ -1,6 +1,6 @@
 package runtime.platform
 
-#import core {*}
+use core {*}
 
 FileData :: #distinct i64
 DirectoryData :: #distinct u64

--- a/core/runtime/platform/onyx/fs.onyx
+++ b/core/runtime/platform/onyx/fs.onyx
@@ -1,5 +1,6 @@
 package runtime.platform
 
+#import core
 use core
 
 FileData :: #distinct i64

--- a/core/runtime/platform/onyx/fs.onyx
+++ b/core/runtime/platform/onyx/fs.onyx
@@ -1,7 +1,6 @@
 package runtime.platform
 
-#import core
-use core
+#import core {*}
 
 FileData :: #distinct i64
 DirectoryData :: #distinct u64

--- a/core/runtime/platform/onyx/platform.onyx
+++ b/core/runtime/platform/onyx/platform.onyx
@@ -2,6 +2,7 @@ package runtime.platform
 
 #import core
 #import runtime
+#import main
 
 use core
 use runtime {
@@ -104,8 +105,8 @@ __start :: () {
     __runtime_initialize();
     context.thread_id = 0;
 
-    #if (typeof (package main).main) == #type () -> void {
-        (package main).main();
+    #if (typeof main.main) == #type () -> void {
+        main.main();
 
     } else {
         args : [] cstr;
@@ -116,7 +117,7 @@ __start :: () {
         argv_buf := cast(cstr) calloc(argv_buf_size);
         __args_get(args.data, argv_buf);
 
-        (package main).main(args);
+        main.main(args);
     }
 
     __flush_stdio();

--- a/core/runtime/platform/onyx/platform.onyx
+++ b/core/runtime/platform/onyx/platform.onyx
@@ -1,11 +1,9 @@
 package runtime.platform
 
-#import core
-#import runtime
-#import main
-
-use core
+use main
+use core {package, *}
 use runtime {
+    package,
     __runtime_initialize,
     Multi_Threading_Enabled,
     _thread_start,

--- a/core/runtime/platform/onyx/platform.onyx
+++ b/core/runtime/platform/onyx/platform.onyx
@@ -1,5 +1,8 @@
 package runtime.platform
 
+#import core
+#import runtime
+
 use core
 use runtime {
     __runtime_initialize,

--- a/core/runtime/platform/wasi/clock.onyx
+++ b/core/runtime/platform/wasi/clock.onyx
@@ -6,7 +6,7 @@ package core.clock
     #error "'core.clock' is only available with the 'wasi' or 'onyx' runtimes.";
 }
 
-use package wasi
+use wasi {package, *}
 
 time :: () -> u64 {
     output_time: Timestamp;

--- a/core/runtime/platform/wasi/env.onyx
+++ b/core/runtime/platform/wasi/env.onyx
@@ -1,16 +1,19 @@
 package core.env
 
-#local runtime :: package runtime
+#import runtime
+#import core.map
+#import core.memory
+#import core.string
+#import wasi
+
+
 #if runtime.runtime != .Wasi 
     && runtime.runtime != .Onyx {
     #error "'core.env' is only available with the 'wasi' and 'onyx' runtimes.";
 }
 
 
-use package wasi { environ_get, environ_sizes_get, Size }
-#package map    :: package core.map
-#package memory :: package core.memory
-#package string :: package core.string
+use wasi { environ_get, environ_sizes_get, Size }
 
 Environment :: struct {
     vars             : Map(str, str);

--- a/core/runtime/platform/wasi/env.onyx
+++ b/core/runtime/platform/wasi/env.onyx
@@ -1,10 +1,10 @@
 package core.env
 
-#import runtime
-#import core.map
-#import core.memory
-#import core.string
-#import wasi
+use runtime
+use core.map
+use core.memory
+use core.string
+use wasi
 
 
 #if runtime.runtime != .Wasi 

--- a/core/runtime/platform/wasi/platform.onyx
+++ b/core/runtime/platform/wasi/platform.onyx
@@ -3,9 +3,9 @@ package runtime.platform
 #load "./wasi_defs"
 #load "./wasi_fs"
 
-#import core
-#import wasi
-#import runtime
+use core
+use wasi
+use runtime
 
 use core
 use wasi {

--- a/core/runtime/platform/wasi/platform.onyx
+++ b/core/runtime/platform/wasi/platform.onyx
@@ -3,6 +3,10 @@ package runtime.platform
 #load "./wasi_defs"
 #load "./wasi_fs"
 
+#import core
+#import wasi
+#import runtime
+
 use core
 use wasi {
     IOVec, SubscriptionTagged, Subscription, Event, Size,

--- a/core/runtime/platform/wasi/wasi_fs.onyx
+++ b/core/runtime/platform/wasi/wasi_fs.onyx
@@ -1,8 +1,8 @@
 package runtime.platform
 
-#import runtime
-#import core
-#import wasi
+use runtime
+use core
+use wasi
 
 use core
 

--- a/core/runtime/platform/wasi/wasi_fs.onyx
+++ b/core/runtime/platform/wasi/wasi_fs.onyx
@@ -1,14 +1,16 @@
 package runtime.platform
 
-#local runtime :: package runtime
+#import runtime
+#import core
+#import wasi
+
+use core
+
 #if runtime.runtime != .Wasi {
     #error "The file system library is currently only available on the WASI runtime, and should only be included if that is the chosen runtime."
 }
 
-use package core
-
-#local wasi :: package wasi
-use package wasi {
+use wasi {
     FileDescriptor,
     FDFlags, OFlags, Rights,
     LookupFlags, Errno,

--- a/core/std.onyx
+++ b/core/std.onyx
@@ -1,5 +1,7 @@
 package core
 
+#import runtime
+
 
 #load "./alloc/alloc"
 #load "./memory/memory"

--- a/core/std.onyx
+++ b/core/std.onyx
@@ -1,6 +1,6 @@
 package core
 
-#import runtime
+use runtime
 
 
 #load "./alloc/alloc"

--- a/core/string/buffer.onyx
+++ b/core/string/buffer.onyx
@@ -6,7 +6,7 @@
 
 package core.string
 
-#import core.math
+use core.math
 
 String_Buffer :: struct {
     data     : [&] u8;

--- a/core/string/buffer.onyx
+++ b/core/string/buffer.onyx
@@ -6,7 +6,7 @@
 
 package core.string
 
-use core {math}
+#import core.math
 
 String_Buffer :: struct {
     data     : [&] u8;

--- a/core/string/string.onyx
+++ b/core/string/string.onyx
@@ -1,5 +1,7 @@
 package core.string
 
+#import core
+
 use core
 
 #doc "Generic procedure for turning something into a string."

--- a/core/string/string.onyx
+++ b/core/string/string.onyx
@@ -652,45 +652,45 @@ bisect :: (s: str, substr: str) -> (str, str) {
 //
 
 to_dyn_str :: (x: str, allocator := context.allocator) -> dyn_str {
-    #import core.array
+    use core.array
     return array.make(x, allocator);
 }
 
 delete  :: macro (x: &dyn_str, idx: u32) -> u8 {
-    #import core.array
+    use core.array
     return array.delete(x, idx);
 }
 
 append  :: #match {
     macro (x: &dyn_str, other: str) {
-        #import core.array
+        use core.array
         array.concat(x, other);
     }, 
 
     macro (x: &dyn_str, other: u8) {
-        #import core.array
+        use core.array
         array.push(x, other);
     }, 
 }
 
 clear   :: macro (x: &dyn_str) {
-    #import core.array
+    use core.array
     array.clear(x);
 }
 
 retreat :: macro (x: &dyn_str, chars := 1) {
-    #import core.array
+    use core.array
     array.pop(x, chars);
 }
 
 insert  :: #match #locked {
     macro (x: &dyn_str, idx: u32, new_str: str) -> bool {
-        #import core.array
+        use core.array
         return array.insert(x, idx, new_str);
     },
 
     macro (x: &dyn_str, idx: u32, ch: u8) -> bool {
-        #import core.array
+        use core.array
         return array.insert(x, idx, ch);
     }
 }

--- a/core/string/string.onyx
+++ b/core/string/string.onyx
@@ -1,8 +1,6 @@
 package core.string
 
-#import core
-
-use core
+use core {package, *}
 
 #doc "Generic procedure for turning something into a string."
 as_str :: #match -> str {}

--- a/core/string/string.onyx
+++ b/core/string/string.onyx
@@ -654,37 +654,45 @@ bisect :: (s: str, substr: str) -> (str, str) {
 //
 
 to_dyn_str :: (x: str, allocator := context.allocator) -> dyn_str {
-    return (package core.array).make(x, allocator);
+    #import core.array
+    return array.make(x, allocator);
 }
 
 delete  :: macro (x: &dyn_str, idx: u32) -> u8 {
-    return (package core.array).delete(x, idx);
+    #import core.array
+    return array.delete(x, idx);
 }
 
 append  :: #match {
     macro (x: &dyn_str, other: str) {
-        (package core.array).concat(x, other);
+        #import core.array
+        array.concat(x, other);
     }, 
 
     macro (x: &dyn_str, other: u8) {
-        (package core.array).push(x, other);
+        #import core.array
+        array.push(x, other);
     }, 
 }
 
 clear   :: macro (x: &dyn_str) {
-    (package core.array).clear(x);
+    #import core.array
+    array.clear(x);
 }
 
 retreat :: macro (x: &dyn_str, chars := 1) {
-    (package core.array).pop(x, chars);
+    #import core.array
+    array.pop(x, chars);
 }
 
 insert  :: #match #locked {
     macro (x: &dyn_str, idx: u32, new_str: str) -> bool {
-        return (package core.array).insert(x, idx, new_str);
+        #import core.array
+        return array.insert(x, idx, new_str);
     },
 
     macro (x: &dyn_str, idx: u32, ch: u8) -> bool {
-        return (package core.array).insert(x, idx, ch);
+        #import core.array
+        return array.insert(x, idx, ch);
     }
 }

--- a/core/string/string_pool.onyx
+++ b/core/string/string_pool.onyx
@@ -1,7 +1,8 @@
 package core.string
 
-use core { alloc, memory }
-use core.alloc { arena }
+#import core.alloc
+#import core.alloc.arena
+#import core.memory
 
 //
 // Many times, storing strings is annoying because you need

--- a/core/string/string_pool.onyx
+++ b/core/string/string_pool.onyx
@@ -1,8 +1,8 @@
 package core.string
 
-#import core.alloc
-#import core.alloc.arena
-#import core.memory
+use core.alloc
+use core.alloc.arena
+use core.memory
 
 //
 // Many times, storing strings is annoying because you need

--- a/core/sync/mutex.onyx
+++ b/core/sync/mutex.onyx
@@ -1,5 +1,8 @@
 package core.sync
 
+#import runtime
+#import core
+
 use core.intrinsics.atomics
 use core.thread { Thread_ID }
 

--- a/core/sync/mutex.onyx
+++ b/core/sync/mutex.onyx
@@ -1,9 +1,8 @@
 package core.sync
 
-#import runtime
-#import core
-
-use core.intrinsics.atomics
+use runtime
+use core
+use core.intrinsics.atomics {*}
 use core.thread { Thread_ID }
 
 //

--- a/core/sync/semaphore.onyx
+++ b/core/sync/semaphore.onyx
@@ -1,7 +1,7 @@
 package core.sync
 
-#import runtime
-#import core
+use runtime
+use core
 
 use core.intrinsics.atomics
 

--- a/core/sync/semaphore.onyx
+++ b/core/sync/semaphore.onyx
@@ -1,5 +1,8 @@
 package core.sync
 
+#import runtime
+#import core
+
 use core.intrinsics.atomics
 
 //

--- a/core/test/testing.onyx
+++ b/core/test/testing.onyx
@@ -1,6 +1,11 @@
 package core.test
 
-use core {array, string, printf}
+#import core
+#import core.array
+#import core.string
+#import runtime
+
+use core {printf}
 
 #doc """
     Test tag. Use this to mark a function as a test.

--- a/core/test/testing.onyx
+++ b/core/test/testing.onyx
@@ -1,9 +1,9 @@
 package core.test
 
-#import core
-#import core.array
-#import core.string
-#import runtime
+use core
+use core.array
+use core.string
+use runtime
 
 use core {printf}
 

--- a/core/threads/thread.onyx
+++ b/core/threads/thread.onyx
@@ -1,5 +1,8 @@
 package core.thread
 
+#import core
+#import runtime
+
 use core
 use core.intrinsics.atomics
 

--- a/core/threads/thread.onyx
+++ b/core/threads/thread.onyx
@@ -1,10 +1,8 @@
 package core.thread
 
-#import core
-#import runtime
-
-use core
-use core.intrinsics.atomics
+use runtime
+use core {*}
+use core.intrinsics.atomics {*}
 
 #package {
     thread_mutex   : sync.Mutex;

--- a/core/time/date.onyx
+++ b/core/time/date.onyx
@@ -1,8 +1,7 @@
 package core.time
 
-#import core
-#import runtime
-use core
+use core {package, *}
+use runtime
 
 Date :: struct {
     year: i32;

--- a/core/time/date.onyx
+++ b/core/time/date.onyx
@@ -1,5 +1,7 @@
 package core.time
 
+#import core
+#import runtime
 use core
 
 Date :: struct {

--- a/core/time/time.onyx
+++ b/core/time/time.onyx
@@ -109,7 +109,7 @@ strftime :: (buf: [] u8, format: [] u8, tm: &Timestamp) -> str {
 }
 
 strptime :: (buf_: [] u8, format_: [] u8, tm: &Timestamp) -> bool {
-    use core
+    use core {*}
 
     #persist weekdays   := str.[ "sunday", "monday", "tuesday", "wednesday", "thursday", "friday", "saturday" ];
     #persist monthnames := str.[ "january", "february", "march", "april", "may", "june", "july", "august", "september", "october", "november", "december" ];

--- a/core/time/time.onyx
+++ b/core/time/time.onyx
@@ -1,9 +1,9 @@
 package core.time
 
-#import core
-#import core.os
-#import core.conv
-#import runtime
+use core
+use core.os
+use core.conv
+use runtime
 
 use runtime.platform {
     __time_gmtime,

--- a/core/time/time.onyx
+++ b/core/time/time.onyx
@@ -1,6 +1,10 @@
 package core.time
 
-use core {os, conv}
+#import core
+#import core.os
+#import core.conv
+#import runtime
+
 use runtime.platform {
     __time_gmtime,
     __time_localtime,

--- a/docs/bugs
+++ b/docs/bugs
@@ -125,7 +125,7 @@ List of known bugs:
     use_package_breaking :: () {
         println("Test 1");
 
-        use package foo
+        use foo
 
         println("Test 2");
     }

--- a/examples/04_fixed_arrays.onyx
+++ b/examples/04_fixed_arrays.onyx
@@ -17,8 +17,7 @@
 
 #load "core/std"
 
-#import core
-use core
+use core {*}
 
 main :: (args: [] cstr) {
     // The following declares a fixed-size array of 10 i32s on the stack. Currently,

--- a/examples/04_fixed_arrays.onyx
+++ b/examples/04_fixed_arrays.onyx
@@ -17,7 +17,8 @@
 
 #load "core/std"
 
-use package core
+#import core
+use core
 
 main :: (args: [] cstr) {
     // The following declares a fixed-size array of 10 i32s on the stack. Currently,

--- a/examples/05_slices.onyx
+++ b/examples/05_slices.onyx
@@ -7,7 +7,8 @@
 
 #load "core/std"
 
-use package core
+#import core
+use core
 
 main :: (args: [] cstr) {
     // A dummy array to demonstrate.

--- a/examples/05_slices.onyx
+++ b/examples/05_slices.onyx
@@ -7,8 +7,7 @@
 
 #load "core/std"
 
-#import core
-use core
+use core {*}
 
 main :: (args: [] cstr) {
     // A dummy array to demonstrate.

--- a/examples/06_dynamic_arrays.onyx
+++ b/examples/06_dynamic_arrays.onyx
@@ -9,8 +9,7 @@
 
 #load "core/std"
 
-#import core
-use core
+use core {*}
 
 main :: (args: [] cstr) {
     // Declaring dynamic arrays in Onyx looks like this. The

--- a/examples/06_dynamic_arrays.onyx
+++ b/examples/06_dynamic_arrays.onyx
@@ -9,7 +9,8 @@
 
 #load "core/std"
 
-use package core
+#import core
+use core
 
 main :: (args: [] cstr) {
     // Declaring dynamic arrays in Onyx looks like this. The

--- a/examples/07_structs.onyx
+++ b/examples/07_structs.onyx
@@ -7,8 +7,7 @@
 
 #load "core/std"
 
-#import core
-use core
+use core {*}
 
 main :: (args: [] cstr) {
 

--- a/examples/07_structs.onyx
+++ b/examples/07_structs.onyx
@@ -7,7 +7,8 @@
 
 #load "core/std"
 
-use package core
+#import core
+use core
 
 main :: (args: [] cstr) {
 

--- a/examples/08_enums.onyx
+++ b/examples/08_enums.onyx
@@ -6,8 +6,7 @@
 
 #load "core/std"
 
-#import core
-use core
+use core {*}
 
 main :: (args: [] cstr) {
     // To declare a simple, use the enum keyword.

--- a/examples/08_enums.onyx
+++ b/examples/08_enums.onyx
@@ -6,7 +6,8 @@
 
 #load "core/std"
 
-use package core
+#import core
+use core
 
 main :: (args: [] cstr) {
     // To declare a simple, use the enum keyword.

--- a/examples/09_for_loops.onyx
+++ b/examples/09_for_loops.onyx
@@ -6,7 +6,7 @@
 
 #load "core/std"
 
-use package core
+use core {package, *}
 
 main :: (args: [] cstr) {
     // Currently, for loops can iterate over five kinds of data structures in Onyx:

--- a/examples/10_switch_statements.onyx
+++ b/examples/10_switch_statements.onyx
@@ -1,6 +1,7 @@
 #load "core/std"
 
-use package core
+#import core
+use core
 
 main :: (args: [] cstr) {
     x := 10 + 3 * 5;

--- a/examples/10_switch_statements.onyx
+++ b/examples/10_switch_statements.onyx
@@ -1,7 +1,6 @@
 #load "core/std"
 
-#import core
-use core
+use core {*}
 
 main :: (args: [] cstr) {
     x := 10 + 3 * 5;

--- a/examples/11_map.onyx
+++ b/examples/11_map.onyx
@@ -1,7 +1,6 @@
 #load "core/std"
 
-#import core
-use core
+use core {*}
 
 main :: (args: [] cstr) {
     // Onyx does not have map type built into the language semantics,

--- a/examples/11_map.onyx
+++ b/examples/11_map.onyx
@@ -1,6 +1,7 @@
 #load "core/std"
 
-use package core
+#import core
+use core
 
 main :: (args: [] cstr) {
     // Onyx does not have map type built into the language semantics,

--- a/examples/12_varargs.onyx
+++ b/examples/12_varargs.onyx
@@ -17,8 +17,7 @@
 
 #load "core/std"
 
-#import core
-use core
+use core {*}
 
 main :: (args: [] cstr) {
 

--- a/examples/12_varargs.onyx
+++ b/examples/12_varargs.onyx
@@ -17,7 +17,8 @@
 
 #load "core/std"
 
-use package core
+#import core
+use core
 
 main :: (args: [] cstr) {
 

--- a/examples/13_use_keyword.onyx
+++ b/examples/13_use_keyword.onyx
@@ -16,7 +16,8 @@
 
 #load "core/std"
 
-use package core
+#import core
+use core
 
 main :: (args: [] cstr) {
     // Here are the uses of 'use' currently.
@@ -25,15 +26,15 @@ main :: (args: [] cstr) {
         // You can 'use' a package. You hopefully already knew this.
         // This brings in all the symbols from the core.alloc package into
         // this scope.
-        use package core.alloc
+        use core.alloc
 
         // You can also restrict and partially rename the symbols that collide
-        use package core.string { string_free :: free }
+        use core.string { string_free :: free }
     }
 
     {
         // You can also 'use' a package that is a subpackage of another package. Here, 'string'
-        // is a subpackage of 'core' and the above 'use package core' makes this package
+        // is a subpackage of 'core' and the above 'use core' makes this package
         // available for you to write code like 'string.equal(...)'. However, because it is
         // a namespace, you can 'use' it.
         use string

--- a/examples/13_use_keyword.onyx
+++ b/examples/13_use_keyword.onyx
@@ -16,8 +16,7 @@
 
 #load "core/std"
 
-#import core
-use core
+use core {*}
 
 main :: (args: [] cstr) {
     // Here are the uses of 'use' currently.
@@ -37,7 +36,7 @@ main :: (args: [] cstr) {
         // is a subpackage of 'core' and the above 'use core' makes this package
         // available for you to write code like 'string.equal(...)'. However, because it is
         // a namespace, you can 'use' it.
-        use string
+        use core.string
 
         s := "   Some string ...";
         t := strip_leading_whitespace(s); // This would have to be 'string.strip_leading_whitespace' otherwise.

--- a/examples/14_overloaded_procs.onyx
+++ b/examples/14_overloaded_procs.onyx
@@ -34,8 +34,7 @@
 
 #load "core/std"
 
-#import core
-use core
+use core {*}
 
 main :: (args: [] cstr) {
     // See the overloaded procedure defined below.
@@ -95,7 +94,7 @@ print_type :: #match {
 Person :: struct { name: str; age: i32; }
 
 // The overload option for hashing a person:
-#match (package core).hash.to_u32 (use p: Person) -> u32 {
+#match hash.to_u32 (use p: Person) -> u32 {
     return hash.to_u32(name) * 16239563 + age;
 }
 

--- a/examples/14_overloaded_procs.onyx
+++ b/examples/14_overloaded_procs.onyx
@@ -34,7 +34,8 @@
 
 #load "core/std"
 
-use package core
+#import core
+use core
 
 main :: (args: [] cstr) {
     // See the overloaded procedure defined below.

--- a/examples/15_polymorphic_procs.onyx
+++ b/examples/15_polymorphic_procs.onyx
@@ -59,8 +59,7 @@ compose :: (a: $A, f: (A) -> $B, g: (B) -> $C) -> C {
 
 #load "core/std"
 
-#import core
-use core
+use core {*}
 
 main :: (args: [] cstr) {
 }

--- a/examples/15_polymorphic_procs.onyx
+++ b/examples/15_polymorphic_procs.onyx
@@ -59,7 +59,8 @@ compose :: (a: $A, f: (A) -> $B, g: (B) -> $C) -> C {
 
 #load "core/std"
 
-use package core
+#import core
+use core
 
 main :: (args: [] cstr) {
 }

--- a/examples/16_pipe_operator.onyx
+++ b/examples/16_pipe_operator.onyx
@@ -1,6 +1,7 @@
 #load "core/std"
 
-use package core { println }
+#import core
+use core { println }
 
 main :: (args: [] cstr) {
     // These functions will be used to demo the pipe operator.

--- a/examples/16_pipe_operator.onyx
+++ b/examples/16_pipe_operator.onyx
@@ -1,6 +1,5 @@
 #load "core/std"
 
-#import core
 use core { println }
 
 main :: (args: [] cstr) {

--- a/examples/17_operator_overload.onyx
+++ b/examples/17_operator_overload.onyx
@@ -1,6 +1,5 @@
 #load "core/std"
-#import core
-use core
+use core {*}
 
 // Operator overloading allows you to define what it means to perform
 // a binary operation between two types. In Onyx, they are defined in

--- a/examples/17_operator_overload.onyx
+++ b/examples/17_operator_overload.onyx
@@ -1,5 +1,6 @@
 #load "core/std"
-use package core
+#import core
+use core
 
 // Operator overloading allows you to define what it means to perform
 // a binary operation between two types. In Onyx, they are defined in

--- a/examples/18_macros.onyx
+++ b/examples/18_macros.onyx
@@ -135,5 +135,4 @@ main :: (args: [] cstr) {
 }
 
 #load "core/std"
-#import core
-use core
+use core {*}

--- a/examples/18_macros.onyx
+++ b/examples/18_macros.onyx
@@ -135,4 +135,5 @@ main :: (args: [] cstr) {
 }
 
 #load "core/std"
-use package core
+#import core
+use core

--- a/examples/19_do_blocks.onyx
+++ b/examples/19_do_blocks.onyx
@@ -66,4 +66,5 @@ main :: (args: [] cstr) {
 }
 
 #load "core/std"
-use package core
+#import core
+use core

--- a/examples/19_do_blocks.onyx
+++ b/examples/19_do_blocks.onyx
@@ -66,5 +66,4 @@ main :: (args: [] cstr) {
 }
 
 #load "core/std"
-#import core
-use core
+use core {*}

--- a/examples/20_auto_return.onyx
+++ b/examples/20_auto_return.onyx
@@ -43,6 +43,5 @@ main :: (args: [] cstr) {
 }
 
 #load "core/std"
-#import core
-use core
+use core {*}
 

--- a/examples/20_auto_return.onyx
+++ b/examples/20_auto_return.onyx
@@ -43,5 +43,6 @@ main :: (args: [] cstr) {
 }
 
 #load "core/std"
-use package core
+#import core
+use core
 

--- a/examples/21_quick_functions.onyx
+++ b/examples/21_quick_functions.onyx
@@ -45,5 +45,4 @@ main :: (args) => {
 }
 
 #load "core/std"
-#import core
-use core
+use core {*}

--- a/examples/21_quick_functions.onyx
+++ b/examples/21_quick_functions.onyx
@@ -45,4 +45,5 @@ main :: (args) => {
 }
 
 #load "core/std"
-use package core
+#import core
+use core

--- a/examples/22_interfaces.onyx
+++ b/examples/22_interfaces.onyx
@@ -135,6 +135,5 @@ main :: (args) => {
 }
 
 #load "core/std"
-#import core
-use core
-use core.intrinsics.onyx
+use core {*}
+use core.intrinsics.onyx {*}

--- a/examples/22_interfaces.onyx
+++ b/examples/22_interfaces.onyx
@@ -135,6 +135,6 @@ main :: (args) => {
 }
 
 #load "core/std"
-
-use package core
-use package core.intrinsics.onyx
+#import core
+use core
+use core.intrinsics.onyx

--- a/examples/50_misc.onyx
+++ b/examples/50_misc.onyx
@@ -67,5 +67,4 @@ main :: (args) => {
 }
 
 #load "core/std"
-#import core
-use core
+use core {*}

--- a/examples/50_misc.onyx
+++ b/examples/50_misc.onyx
@@ -67,4 +67,5 @@ main :: (args) => {
 }
 
 #load "core/std"
-use package core
+#import core
+use core

--- a/scripts/run_tests.onyx
+++ b/scripts/run_tests.onyx
@@ -5,10 +5,8 @@
 
 #load "core/std"
 
-#import core
-#import runtime
-
-use core
+use runtime
+use core {package, *}
 use core.intrinsics.onyx { init }
 
 Color :: enum {
@@ -123,7 +121,7 @@ main :: (args) => {
 
     iter.parallel_for(cases, settings.threads, &exec_context) {
         // Weird macros mean I have to forward external names
-        use core
+        use core {*}
         print_color :: print_color;
 
         args: [] str;

--- a/scripts/run_tests.onyx
+++ b/scripts/run_tests.onyx
@@ -5,6 +5,9 @@
 
 #load "core/std"
 
+#import core
+#import runtime
+
 use core
 use core.intrinsics.onyx { init }
 

--- a/tests/aoc-2020/day1.onyx
+++ b/tests/aoc-2020/day1.onyx
@@ -1,8 +1,8 @@
 #load "core/std"
 
-#import core
-#import core.io
-#import core.array
+use core
+use core.io
+use core.array
 use core {printf}
 
 main :: (args: [] cstr) {

--- a/tests/aoc-2020/day1.onyx
+++ b/tests/aoc-2020/day1.onyx
@@ -1,6 +1,9 @@
 #load "core/std"
 
-use package core
+#import core
+#import core.io
+#import core.array
+use core {printf}
 
 main :: (args: [] cstr) {
     contents := #file_contents "./tests/aoc-2020/input/day1.txt";

--- a/tests/aoc-2020/day10.onyx
+++ b/tests/aoc-2020/day10.onyx
@@ -1,6 +1,6 @@
 #load "core/std"
 
-#import core {*}
+use core {*}
 
 count_ending_paths :: (nums: [..] u32) -> u64 {
     tally := array.make(u64, nums.count);

--- a/tests/aoc-2020/day10.onyx
+++ b/tests/aoc-2020/day10.onyx
@@ -1,7 +1,6 @@
 #load "core/std"
 
-#import core
-use core
+#import core {*}
 
 count_ending_paths :: (nums: [..] u32) -> u64 {
     tally := array.make(u64, nums.count);

--- a/tests/aoc-2020/day10.onyx
+++ b/tests/aoc-2020/day10.onyx
@@ -1,6 +1,7 @@
 #load "core/std"
 
-use package core
+#import core
+use core
 
 count_ending_paths :: (nums: [..] u32) -> u64 {
     tally := array.make(u64, nums.count);

--- a/tests/aoc-2020/day11.onyx
+++ b/tests/aoc-2020/day11.onyx
@@ -1,7 +1,4 @@
-#load "core/std"
-
-#import core
-use core
+use core {package, *}
 
 GameOfSeats :: struct {
     width  : u32;

--- a/tests/aoc-2020/day11.onyx
+++ b/tests/aoc-2020/day11.onyx
@@ -1,6 +1,7 @@
 #load "core/std"
 
-use package core
+#import core
+use core
 
 GameOfSeats :: struct {
     width  : u32;

--- a/tests/aoc-2020/day12.onyx
+++ b/tests/aoc-2020/day12.onyx
@@ -1,6 +1,6 @@
 #load "core/std"
 
-use package core
+#import core {*}
 
 Ship :: struct {
     x : i32 = 0;

--- a/tests/aoc-2020/day12.onyx
+++ b/tests/aoc-2020/day12.onyx
@@ -1,6 +1,6 @@
 #load "core/std"
 
-#import core {*}
+use core {*}
 
 Ship :: struct {
     x : i32 = 0;

--- a/tests/aoc-2020/day13.onyx
+++ b/tests/aoc-2020/day13.onyx
@@ -1,6 +1,6 @@
 #load "core/std"
 
-use package core
+#import core {*}
 
 inv_mod :: (a_: i64, m_: i64) -> i64 {
     if m_ <= 1 do return 0;

--- a/tests/aoc-2020/day13.onyx
+++ b/tests/aoc-2020/day13.onyx
@@ -1,6 +1,6 @@
 #load "core/std"
 
-#import core {*}
+use core {*}
 
 inv_mod :: (a_: i64, m_: i64) -> i64 {
     if m_ <= 1 do return 0;

--- a/tests/aoc-2020/day14.onyx
+++ b/tests/aoc-2020/day14.onyx
@@ -1,6 +1,6 @@
 #load "core/std"
 
-use package core
+#import core {*}
 
 MASK_SIZE :: 36
 Bitmask :: [MASK_SIZE] u8;

--- a/tests/aoc-2020/day14.onyx
+++ b/tests/aoc-2020/day14.onyx
@@ -1,6 +1,6 @@
 #load "core/std"
 
-#import core {*}
+use core {*}
 
 MASK_SIZE :: 36
 Bitmask :: [MASK_SIZE] u8;

--- a/tests/aoc-2020/day15.onyx
+++ b/tests/aoc-2020/day15.onyx
@@ -1,6 +1,6 @@
 #load "core/std"
 
-#import core {*}
+use core {*}
 
 initial_numbers := u32.[ 1, 20, 8, 12, 0, 14 ];
 

--- a/tests/aoc-2020/day15.onyx
+++ b/tests/aoc-2020/day15.onyx
@@ -1,6 +1,6 @@
 #load "core/std"
 
-use package core
+#import core {*}
 
 initial_numbers := u32.[ 1, 20, 8, 12, 0, 14 ];
 

--- a/tests/aoc-2020/day16.onyx
+++ b/tests/aoc-2020/day16.onyx
@@ -1,6 +1,6 @@
 #load "core/std"
 
-#import core {*}
+use core {*}
 
 Field :: struct {
 	name : str = "";

--- a/tests/aoc-2020/day16.onyx
+++ b/tests/aoc-2020/day16.onyx
@@ -1,6 +1,6 @@
 #load "core/std"
 
-use package core
+#import core {*}
 
 Field :: struct {
 	name : str = "";

--- a/tests/aoc-2020/day17.onyx
+++ b/tests/aoc-2020/day17.onyx
@@ -1,7 +1,6 @@
 #load "core/std"
 
-#import core
-use core
+use core {package, *}
 
 OverloadsEqual :: interface (t: $T) {
     { T.equals(t, t) } -> bool;

--- a/tests/aoc-2020/day17.onyx
+++ b/tests/aoc-2020/day17.onyx
@@ -1,5 +1,6 @@
 #load "core/std"
 
+#import core
 use core
 
 OverloadsEqual :: interface (t: $T) {

--- a/tests/aoc-2020/day18.onyx
+++ b/tests/aoc-2020/day18.onyx
@@ -1,6 +1,6 @@
 #load "core/std"
 
-#import core {*}
+use core {*}
 
 parse_factor :: (file: &str) -> u64 {
 	string.strip_leading_whitespace(file);

--- a/tests/aoc-2020/day18.onyx
+++ b/tests/aoc-2020/day18.onyx
@@ -1,6 +1,6 @@
 #load "core/std"
 
-use package core
+#import core {*}
 
 parse_factor :: (file: &str) -> u64 {
 	string.strip_leading_whitespace(file);

--- a/tests/aoc-2020/day19.onyx
+++ b/tests/aoc-2020/day19.onyx
@@ -1,6 +1,6 @@
 #load "core/std"
 
-#import core {*}
+use core {*}
 
 // nt -> t
 Term :: struct {

--- a/tests/aoc-2020/day19.onyx
+++ b/tests/aoc-2020/day19.onyx
@@ -1,6 +1,6 @@
 #load "core/std"
 
-use package core
+#import core {*}
 
 // nt -> t
 Term :: struct {

--- a/tests/aoc-2020/day2.onyx
+++ b/tests/aoc-2020/day2.onyx
@@ -2,7 +2,7 @@ package main
 
 #load "core/std"
 
-use package core
+#import core {*}
 
 main :: (args: [] cstr) {
     contents := #file_contents "./tests/aoc-2020/input/day2.txt";

--- a/tests/aoc-2020/day2.onyx
+++ b/tests/aoc-2020/day2.onyx
@@ -2,7 +2,7 @@ package main
 
 #load "core/std"
 
-#import core {*}
+use core {*}
 
 main :: (args: [] cstr) {
     contents := #file_contents "./tests/aoc-2020/input/day2.txt";

--- a/tests/aoc-2020/day20.onyx
+++ b/tests/aoc-2020/day20.onyx
@@ -1,6 +1,6 @@
 #load "core/std"
 
-use package core
+#import core {*}
 
 TILE_DATA_WIDTH  :: 10
 TILE_DATA_HEIGHT :: 10

--- a/tests/aoc-2020/day20.onyx
+++ b/tests/aoc-2020/day20.onyx
@@ -1,6 +1,6 @@
 #load "core/std"
 
-#import core {*}
+use core {*}
 
 TILE_DATA_WIDTH  :: 10
 TILE_DATA_HEIGHT :: 10

--- a/tests/aoc-2020/day21.onyx
+++ b/tests/aoc-2020/day21.onyx
@@ -1,6 +1,6 @@
 #load "core/std"
 
-use package core
+#import core {*}
 
 /*
 	What questions the data layout needs to answer easily:

--- a/tests/aoc-2020/day21.onyx
+++ b/tests/aoc-2020/day21.onyx
@@ -1,6 +1,6 @@
 #load "core/std"
 
-#import core {*}
+use core {*}
 
 /*
 	What questions the data layout needs to answer easily:

--- a/tests/aoc-2020/day22.onyx
+++ b/tests/aoc-2020/day22.onyx
@@ -1,6 +1,6 @@
 #load "core/std"
 
-#import core {*}
+use core {*}
 
 key_arena : alloc.arena.ArenaState;
 key_alloc : Allocator;

--- a/tests/aoc-2020/day22.onyx
+++ b/tests/aoc-2020/day22.onyx
@@ -1,6 +1,6 @@
 #load "core/std"
 
-use package core
+#import core {*}
 
 key_arena : alloc.arena.ArenaState;
 key_alloc : Allocator;

--- a/tests/aoc-2020/day23.onyx
+++ b/tests/aoc-2020/day23.onyx
@@ -1,6 +1,6 @@
 #load "core/std"
 
-use package core
+#import core {*}
 
 cups : [..] i32;
 

--- a/tests/aoc-2020/day23.onyx
+++ b/tests/aoc-2020/day23.onyx
@@ -1,6 +1,6 @@
 #load "core/std"
 
-#import core {*}
+use core {*}
 
 cups : [..] i32;
 

--- a/tests/aoc-2020/day24.onyx
+++ b/tests/aoc-2020/day24.onyx
@@ -1,6 +1,6 @@
 #load "core/std"
 
-use package core
+#import core {*}
 
 Vec2 :: struct {
 	x: i32 = 0;

--- a/tests/aoc-2020/day24.onyx
+++ b/tests/aoc-2020/day24.onyx
@@ -1,6 +1,6 @@
 #load "core/std"
 
-#import core {*}
+use core {*}
 
 Vec2 :: struct {
 	x: i32 = 0;

--- a/tests/aoc-2020/day25.onyx
+++ b/tests/aoc-2020/day25.onyx
@@ -1,6 +1,6 @@
 #load "core/std"
 
-use package core
+#import core {*}
 
 power_mod :: (base: u32, exp: u32, mod: u32) -> u32 {
     t: u64 = 1;

--- a/tests/aoc-2020/day25.onyx
+++ b/tests/aoc-2020/day25.onyx
@@ -1,6 +1,6 @@
 #load "core/std"
 
-#import core {*}
+use core {*}
 
 power_mod :: (base: u32, exp: u32, mod: u32) -> u32 {
     t: u64 = 1;

--- a/tests/aoc-2020/day3.onyx
+++ b/tests/aoc-2020/day3.onyx
@@ -1,6 +1,6 @@
 #load "core/std"
 
-#import core {*}
+use core {*}
 
 Point :: struct {
     x, y : i32;

--- a/tests/aoc-2020/day3.onyx
+++ b/tests/aoc-2020/day3.onyx
@@ -1,6 +1,6 @@
 #load "core/std"
 
-use package core
+#import core {*}
 
 Point :: struct {
     x, y : i32;

--- a/tests/aoc-2020/day4.onyx
+++ b/tests/aoc-2020/day4.onyx
@@ -1,6 +1,6 @@
 #load "core/std"
 
-use package core
+#import core {*}
 
 // Returns the number of fields
 process_passport :: (contents: &str) -> u32 {

--- a/tests/aoc-2020/day4.onyx
+++ b/tests/aoc-2020/day4.onyx
@@ -1,6 +1,6 @@
 #load "core/std"
 
-#import core {*}
+use core {*}
 
 // Returns the number of fields
 process_passport :: (contents: &str) -> u32 {

--- a/tests/aoc-2020/day5.onyx
+++ b/tests/aoc-2020/day5.onyx
@@ -1,6 +1,6 @@
 #load "core/std"
 
-#import core {*}
+use core {*}
 
 main :: (args: [] cstr) {
     contents := #file_contents "./tests/aoc-2020/input/day5.txt";

--- a/tests/aoc-2020/day5.onyx
+++ b/tests/aoc-2020/day5.onyx
@@ -1,6 +1,6 @@
 #load "core/std"
 
-use package core
+#import core {*}
 
 main :: (args: [] cstr) {
     contents := #file_contents "./tests/aoc-2020/input/day5.txt";

--- a/tests/aoc-2020/day6.onyx
+++ b/tests/aoc-2020/day6.onyx
@@ -1,6 +1,6 @@
 #load "core/std"
 
-use package core
+#import core {*}
 
 part_1 :: (contents: &str) -> u32 {
     chars : [26] bool;

--- a/tests/aoc-2020/day6.onyx
+++ b/tests/aoc-2020/day6.onyx
@@ -1,6 +1,6 @@
 #load "core/std"
 
-#import core {*}
+use core {*}
 
 part_1 :: (contents: &str) -> u32 {
     chars : [26] bool;

--- a/tests/aoc-2020/day7.onyx
+++ b/tests/aoc-2020/day7.onyx
@@ -1,6 +1,6 @@
 #load "core/std"
 
-#import core {*}
+use core {*}
 
 BagGraph :: struct {
     nodes    : [..] &BagNode;

--- a/tests/aoc-2020/day7.onyx
+++ b/tests/aoc-2020/day7.onyx
@@ -1,6 +1,6 @@
 #load "core/std"
 
-use package core
+#import core {*}
 
 BagGraph :: struct {
     nodes    : [..] &BagNode;

--- a/tests/aoc-2020/day8.onyx
+++ b/tests/aoc-2020/day8.onyx
@@ -1,6 +1,6 @@
 #load "core/std"
 
-use package core
+#import core {*}
 
 OpCode :: enum (u16) {
     Nop; Acc; Jmp;

--- a/tests/aoc-2020/day8.onyx
+++ b/tests/aoc-2020/day8.onyx
@@ -1,6 +1,6 @@
 #load "core/std"
 
-#import core {*}
+use core {*}
 
 OpCode :: enum (u16) {
     Nop; Acc; Jmp;

--- a/tests/aoc-2020/day9.onyx
+++ b/tests/aoc-2020/day9.onyx
@@ -1,6 +1,6 @@
 #load "core/std"
 
-use package core
+#import core {*}
 
 find_contiguous_subarray_with_sum :: (nums: [..] u64, sum: u64) -> (i32, i32) {
     start := 0;

--- a/tests/aoc-2020/day9.onyx
+++ b/tests/aoc-2020/day9.onyx
@@ -1,6 +1,6 @@
 #load "core/std"
 
-#import core {*}
+use core {*}
 
 find_contiguous_subarray_with_sum :: (nums: [..] u64, sum: u64) -> (i32, i32) {
     start := 0;

--- a/tests/aoc-2021/day01.onyx
+++ b/tests/aoc-2021/day01.onyx
@@ -1,6 +1,8 @@
 #load "core/std"
 
-use package core
+#import core.io
+#import core.os
+#import core {printf}
 
 count_increasing :: (arr: [] $T) -> u32 {
     increased_count := 0;

--- a/tests/aoc-2021/day01.onyx
+++ b/tests/aoc-2021/day01.onyx
@@ -1,8 +1,8 @@
 #load "core/std"
 
-#import core.io
-#import core.os
-#import core {printf}
+use core.io
+use core.os
+use core {printf}
 
 count_increasing :: (arr: [] $T) -> u32 {
     increased_count := 0;

--- a/tests/aoc-2021/day02.onyx
+++ b/tests/aoc-2021/day02.onyx
@@ -1,6 +1,6 @@
 PART :: 2
 
-#import core {*}
+use core {*}
 
 main :: (args) => {
     for file: os.with_file("tests/aoc-2021/input/day02.txt") {

--- a/tests/aoc-2021/day02.onyx
+++ b/tests/aoc-2021/day02.onyx
@@ -1,8 +1,6 @@
 PART :: 2
 
-#load "core/std"
-
-use package core
+#import core {*}
 
 main :: (args) => {
     for file: os.with_file("tests/aoc-2021/input/day02.txt") {

--- a/tests/aoc-2021/day03.onyx
+++ b/tests/aoc-2021/day03.onyx
@@ -2,7 +2,7 @@ PART :: 2
 
 #load "core/std"
 
-#import core {*}
+use core {*}
 
 read_binary :: (r: &io.Reader) -> i32 {
     n := 0;

--- a/tests/aoc-2021/day03.onyx
+++ b/tests/aoc-2021/day03.onyx
@@ -2,7 +2,7 @@ PART :: 2
 
 #load "core/std"
 
-use package core
+#import core {*}
 
 read_binary :: (r: &io.Reader) -> i32 {
     n := 0;

--- a/tests/aoc-2021/day04.onyx
+++ b/tests/aoc-2021/day04.onyx
@@ -1,6 +1,6 @@
 #load "core/std"
 
-use package core
+#import core {*}
 
 Cell :: u8
 

--- a/tests/aoc-2021/day04.onyx
+++ b/tests/aoc-2021/day04.onyx
@@ -1,6 +1,6 @@
 #load "core/std"
 
-#import core {*}
+use core {*}
 
 Cell :: u8
 

--- a/tests/aoc-2021/day05.onyx
+++ b/tests/aoc-2021/day05.onyx
@@ -1,6 +1,6 @@
 #load "core/std"
 
-use package core
+#import core {*}
 
 Line :: struct {
     x1, y1: i32;

--- a/tests/aoc-2021/day05.onyx
+++ b/tests/aoc-2021/day05.onyx
@@ -1,6 +1,6 @@
 #load "core/std"
 
-#import core {*}
+use core {*}
 
 Line :: struct {
     x1, y1: i32;

--- a/tests/aoc-2021/day06.onyx
+++ b/tests/aoc-2021/day06.onyx
@@ -1,6 +1,6 @@
 #load "core/std"
 
-#import core {*}
+use core {*}
 
 main :: (args) => {
     for file: os.with_file("./tests/aoc-2021/input/day06.txt") {

--- a/tests/aoc-2021/day06.onyx
+++ b/tests/aoc-2021/day06.onyx
@@ -1,6 +1,6 @@
 #load "core/std"
 
-use package core
+#import core {*}
 
 main :: (args) => {
     for file: os.with_file("./tests/aoc-2021/input/day06.txt") {

--- a/tests/aoc-2021/day07.onyx
+++ b/tests/aoc-2021/day07.onyx
@@ -1,6 +1,6 @@
 #load "core/std"
 
-use package core
+#import core {*}
 
 main :: (args) => {
     for file: os.with_file("./tests/aoc-2021/input/day07.txt") {

--- a/tests/aoc-2021/day07.onyx
+++ b/tests/aoc-2021/day07.onyx
@@ -1,6 +1,6 @@
 #load "core/std"
 
-#import core {*}
+use core {*}
 
 main :: (args) => {
     for file: os.with_file("./tests/aoc-2021/input/day07.txt") {

--- a/tests/aoc-2021/day08.onyx
+++ b/tests/aoc-2021/day08.onyx
@@ -1,7 +1,7 @@
 PART :: 2
 #load "core/std"
 
-#import core {*}
+use core {*}
 
 // Encoded segments
 //

--- a/tests/aoc-2021/day08.onyx
+++ b/tests/aoc-2021/day08.onyx
@@ -1,7 +1,7 @@
 PART :: 2
 #load "core/std"
 
-use package core
+#import core {*}
 
 // Encoded segments
 //

--- a/tests/aoc-2021/day09.onyx
+++ b/tests/aoc-2021/day09.onyx
@@ -1,6 +1,6 @@
 #load "core/std"
 
-#import core {*}
+use core {*}
 
 Pos :: struct {x,y: i32;}
 #match hash.to_u32 (use p: Pos) => x * 13 & 17 * y;

--- a/tests/aoc-2021/day09.onyx
+++ b/tests/aoc-2021/day09.onyx
@@ -1,6 +1,6 @@
 #load "core/std"
 
-use package core
+#import core {*}
 
 Pos :: struct {x,y: i32;}
 #match hash.to_u32 (use p: Pos) => x * 13 & 17 * y;

--- a/tests/aoc-2021/day10.onyx
+++ b/tests/aoc-2021/day10.onyx
@@ -1,6 +1,6 @@
 #load "core/std"
 
-#import core {*}
+use core {*}
 
 main :: (args) => {
     for file: os.with_file("./tests/aoc-2021/input/day10.txt") {

--- a/tests/aoc-2021/day10.onyx
+++ b/tests/aoc-2021/day10.onyx
@@ -1,6 +1,6 @@
 #load "core/std"
 
-use package core
+#import core {*}
 
 main :: (args) => {
     for file: os.with_file("./tests/aoc-2021/input/day10.txt") {

--- a/tests/aoc-2021/day11.onyx
+++ b/tests/aoc-2021/day11.onyx
@@ -1,6 +1,6 @@
 #load "core/std"
 
-#import core {*}
+use core {*}
 
 Pos :: struct {x, y:i32;}
 #match hash.to_u32 (use p: Pos) => x * 45238271 + y * 34725643;

--- a/tests/aoc-2021/day11.onyx
+++ b/tests/aoc-2021/day11.onyx
@@ -1,6 +1,6 @@
 #load "core/std"
 
-use package core
+#import core {*}
 
 Pos :: struct {x, y:i32;}
 #match hash.to_u32 (use p: Pos) => x * 45238271 + y * 34725643;

--- a/tests/aoc-2021/day12.onyx
+++ b/tests/aoc-2021/day12.onyx
@@ -1,6 +1,6 @@
 #load "core/std"
 
-use package core
+#import core {*}
 
 Communative_Pair :: struct (T: type_expr) where hash.Hashable(T) {
     a, b: T;

--- a/tests/aoc-2021/day12.onyx
+++ b/tests/aoc-2021/day12.onyx
@@ -1,6 +1,6 @@
 #load "core/std"
 
-#import core {*}
+use core {*}
 
 Communative_Pair :: struct (T: type_expr) where hash.Hashable(T) {
     a, b: T;

--- a/tests/aoc-2021/day13.onyx
+++ b/tests/aoc-2021/day13.onyx
@@ -1,6 +1,6 @@
 #load "core/std"
 
-#import core {*}
+use core {*}
 
 Point :: struct {
     x, y: i32;

--- a/tests/aoc-2021/day13.onyx
+++ b/tests/aoc-2021/day13.onyx
@@ -1,6 +1,6 @@
 #load "core/std"
 
-use package core
+#import core {*}
 
 Point :: struct {
     x, y: i32;

--- a/tests/aoc-2021/day14.onyx
+++ b/tests/aoc-2021/day14.onyx
@@ -1,6 +1,6 @@
 #load "core/std"
 
-use package core
+#import core {*}
 
 Rule :: struct {
     pair: Pair(u8, u8);

--- a/tests/aoc-2021/day14.onyx
+++ b/tests/aoc-2021/day14.onyx
@@ -1,6 +1,6 @@
 #load "core/std"
 
-#import core {*}
+use core {*}
 
 Rule :: struct {
     pair: Pair(u8, u8);

--- a/tests/aoc-2021/day15.onyx
+++ b/tests/aoc-2021/day15.onyx
@@ -1,6 +1,6 @@
 #load "core/std"
 
-use package core
+#import core {*}
 
 queued :: struct { x, y: i32; cost: i32; };
 #operator == (u1, u2: queued) => u1.x == u2.x && u1.y == u2.y;

--- a/tests/aoc-2021/day15.onyx
+++ b/tests/aoc-2021/day15.onyx
@@ -1,6 +1,6 @@
 #load "core/std"
 
-#import core {*}
+use core {*}
 
 queued :: struct { x, y: i32; cost: i32; };
 #operator == (u1, u2: queued) => u1.x == u2.x && u1.y == u2.y;

--- a/tests/aoc-2021/day16.onyx
+++ b/tests/aoc-2021/day16.onyx
@@ -1,6 +1,6 @@
 #load "core/std"
 
-use package core
+#import core {*}
 
 base16_to_hex :: (s: str) -> u32 {
     res := 0;

--- a/tests/aoc-2021/day16.onyx
+++ b/tests/aoc-2021/day16.onyx
@@ -1,6 +1,6 @@
 #load "core/std"
 
-#import core {*}
+use core {*}
 
 base16_to_hex :: (s: str) -> u32 {
     res := 0;

--- a/tests/aoc-2021/day17.onyx
+++ b/tests/aoc-2021/day17.onyx
@@ -1,6 +1,6 @@
 #load "core/std"
 
-use package core
+#import core {*}
 
 tx0: i32
 ty0: i32

--- a/tests/aoc-2021/day17.onyx
+++ b/tests/aoc-2021/day17.onyx
@@ -1,6 +1,6 @@
 #load "core/std"
 
-#import core {*}
+use core {*}
 
 tx0: i32
 ty0: i32

--- a/tests/aoc-2021/day18.onyx
+++ b/tests/aoc-2021/day18.onyx
@@ -2,6 +2,8 @@
 
 PART :: 2
 
+#import core
+
 use core
 use core.alloc {arena}
 

--- a/tests/aoc-2021/day18.onyx
+++ b/tests/aoc-2021/day18.onyx
@@ -2,9 +2,7 @@
 
 PART :: 2
 
-#import core
-
-use core
+use core {package, *}
 use core.alloc {arena}
 
 num_allocator: Allocator;

--- a/tests/aoc-2021/day21.onyx
+++ b/tests/aoc-2021/day21.onyx
@@ -1,3 +1,4 @@
+#import core
 use core
 
 PART :: 1

--- a/tests/aoc-2021/day21.onyx
+++ b/tests/aoc-2021/day21.onyx
@@ -1,5 +1,4 @@
-#import core
-use core
+use core {package, *}
 
 PART :: 1
 

--- a/tests/array_struct_robustness.onyx
+++ b/tests/array_struct_robustness.onyx
@@ -1,6 +1,6 @@
 #load "core/std"
 
-#import core {*}
+use core {*}
 
 Vec2 :: struct { x: i32; y: i32; }
 

--- a/tests/array_struct_robustness.onyx
+++ b/tests/array_struct_robustness.onyx
@@ -1,6 +1,6 @@
 #load "core/std"
 
-use package core
+#import core {*}
 
 Vec2 :: struct { x: i32; y: i32; }
 

--- a/tests/arrow_notation.onyx
+++ b/tests/arrow_notation.onyx
@@ -1,6 +1,9 @@
 #load "core/std"
 
-use core
+#import core
+#import core.conv
+
+use core {println}
 
 #tag conv.Custom_Format.{format}
 V2 :: struct {

--- a/tests/arrow_notation.onyx
+++ b/tests/arrow_notation.onyx
@@ -1,7 +1,7 @@
 #load "core/std"
 
-#import core
-#import core.conv
+use core
+use core.conv
 
 use core {println}
 

--- a/tests/atomics.onyx
+++ b/tests/atomics.onyx
@@ -1,8 +1,8 @@
 #load "core/std"
 #load "core/intrinsics/atomics"
 
-#import core {*}
-#import core.intrinsics.atomics {*}
+use core {*}
+use core.intrinsics.atomics {*}
 
 Shared_Data :: struct {
     arr: [] i32;

--- a/tests/atomics.onyx
+++ b/tests/atomics.onyx
@@ -1,8 +1,8 @@
 #load "core/std"
 #load "core/intrinsics/atomics"
 
-use package core
-use package core.intrinsics.atomics
+#import core {*}
+#import core.intrinsics.atomics {*}
 
 Shared_Data :: struct {
     arr: [] i32;

--- a/tests/auto_poly.onyx
+++ b/tests/auto_poly.onyx
@@ -1,6 +1,6 @@
 #load "core/std"
 
-#import core {*}
+use core {*}
 
 dumb :: (it: Iterator, m: &Map) {
     println(it.Iter_Type);

--- a/tests/auto_poly.onyx
+++ b/tests/auto_poly.onyx
@@ -1,6 +1,6 @@
 #load "core/std"
 
-use package core
+#import core {*}
 
 dumb :: (it: Iterator, m: &Map) {
     println(it.Iter_Type);

--- a/tests/avl_test.onyx
+++ b/tests/avl_test.onyx
@@ -1,6 +1,6 @@
 #load "core/std"
 
-#import core {*}
+use core {*}
 
 main :: () {
     tree: &avl_tree.AVL_Tree(i32);

--- a/tests/avl_test.onyx
+++ b/tests/avl_test.onyx
@@ -1,6 +1,6 @@
 #load "core/std"
 
-use package core
+#import core {*}
 
 main :: () {
     tree: &avl_tree.AVL_Tree(i32);

--- a/tests/baked_parameters.onyx
+++ b/tests/baked_parameters.onyx
@@ -1,6 +1,6 @@
 #load "core/std"
 
-use package core
+#import core {*}
 
 count_to :: ($N: i32) {
     for i: 0 .. N do printf("{} ", i);

--- a/tests/baked_parameters.onyx
+++ b/tests/baked_parameters.onyx
@@ -1,6 +1,6 @@
 #load "core/std"
 
-#import core {*}
+use core {*}
 
 count_to :: ($N: i32) {
     for i: 0 .. N do printf("{} ", i);

--- a/tests/better_field_accesses.onyx
+++ b/tests/better_field_accesses.onyx
@@ -1,6 +1,6 @@
 #load "core/std"
 
-#import core {*}
+use core {*}
 
 Foo :: struct {
     x, y: i32;

--- a/tests/better_field_accesses.onyx
+++ b/tests/better_field_accesses.onyx
@@ -1,6 +1,6 @@
 #load "core/std"
 
-use package core
+#import core {*}
 
 Foo :: struct {
     x, y: i32;

--- a/tests/bucket_array.onyx
+++ b/tests/bucket_array.onyx
@@ -1,6 +1,6 @@
 #load "core/std"
 
-#import core {*}
+use core {*}
 
 main :: (args: [] cstr) {
     ba := bucket_array.make(i32, 4);

--- a/tests/bucket_array.onyx
+++ b/tests/bucket_array.onyx
@@ -1,6 +1,6 @@
 #load "core/std"
 
-use package core
+#import core {*}
 
 main :: (args: [] cstr) {
     ba := bucket_array.make(i32, 4);

--- a/tests/bugs/anonymous_struct_defaults.onyx
+++ b/tests/bugs/anonymous_struct_defaults.onyx
@@ -1,6 +1,6 @@
 #load "core/std"
 
-use package core
+#import core {*}
 
 S :: struct {
     some_array: [..] struct {

--- a/tests/bugs/anonymous_struct_defaults.onyx
+++ b/tests/bugs/anonymous_struct_defaults.onyx
@@ -1,6 +1,6 @@
 #load "core/std"
 
-#import core {*}
+use core {*}
 
 S :: struct {
     some_array: [..] struct {

--- a/tests/bugs/autopoly_limits.onyx
+++ b/tests/bugs/autopoly_limits.onyx
@@ -1,3 +1,4 @@
+#import core
 use core
 
 f :: ctx => {

--- a/tests/bugs/autopoly_limits.onyx
+++ b/tests/bugs/autopoly_limits.onyx
@@ -1,5 +1,4 @@
-#import core
-use core
+use core {package, *}
 
 f :: ctx => {
     x, y := 123, 456.0f;

--- a/tests/bugs/defer_block_in_macro.onyx
+++ b/tests/bugs/defer_block_in_macro.onyx
@@ -1,6 +1,6 @@
 #load "core/std"
 
-use package core
+#import core {*}
 
 test_macro :: macro () {
     defer {

--- a/tests/bugs/defer_block_in_macro.onyx
+++ b/tests/bugs/defer_block_in_macro.onyx
@@ -1,6 +1,6 @@
 #load "core/std"
 
-#import core {*}
+use core {*}
 
 test_macro :: macro () {
     defer {

--- a/tests/bugs/double_polymorph_yield_error.onyx
+++ b/tests/bugs/double_polymorph_yield_error.onyx
@@ -1,5 +1,4 @@
-#load "core/std"
-
+#import core
 use core
 
 q :: (v: &$C, g: (&C) -> $T) {

--- a/tests/bugs/double_polymorph_yield_error.onyx
+++ b/tests/bugs/double_polymorph_yield_error.onyx
@@ -1,5 +1,4 @@
-#import core
-use core
+use core {package, *}
 
 q :: (v: &$C, g: (&C) -> $T) {
     println(*v);

--- a/tests/bugs/fallthrough_defer_interaction.onyx
+++ b/tests/bugs/fallthrough_defer_interaction.onyx
@@ -1,6 +1,6 @@
 #load "core/std"
 
-#import core {*}
+use core {*}
 
 custom_iterator :: () -> Iterator(i32) {
 

--- a/tests/bugs/fallthrough_defer_interaction.onyx
+++ b/tests/bugs/fallthrough_defer_interaction.onyx
@@ -1,6 +1,6 @@
 #load "core/std"
 
-use package core
+#import core {*}
 
 custom_iterator :: () -> Iterator(i32) {
 

--- a/tests/bugs/macro_auto_return_not_resolved.onyx
+++ b/tests/bugs/macro_auto_return_not_resolved.onyx
@@ -1,6 +1,6 @@
 #load "core/std"
 
-#import core {*}
+use core {*}
 
 Point :: struct { x, y: i32; }
 

--- a/tests/bugs/macro_auto_return_not_resolved.onyx
+++ b/tests/bugs/macro_auto_return_not_resolved.onyx
@@ -1,6 +1,6 @@
 #load "core/std"
 
-use package core
+#import core {*}
 
 Point :: struct { x, y: i32; }
 

--- a/tests/bugs/method_call_source_double.onyx
+++ b/tests/bugs/method_call_source_double.onyx
@@ -1,5 +1,4 @@
-#import core
-use core
+use core {package, *}
 
 Foo :: struct {
     use vtable: &VTable;

--- a/tests/bugs/method_call_source_double.onyx
+++ b/tests/bugs/method_call_source_double.onyx
@@ -1,5 +1,4 @@
-#load "core/std"
-
+#import core
 use core
 
 Foo :: struct {

--- a/tests/bugs/namespace_aliasing.onyx
+++ b/tests/bugs/namespace_aliasing.onyx
@@ -1,5 +1,5 @@
 #load "core/std"
-#import core {*}
+use core {*}
 
 SomeNamespace :: struct {
     foo :: () {

--- a/tests/bugs/namespace_aliasing.onyx
+++ b/tests/bugs/namespace_aliasing.onyx
@@ -1,5 +1,5 @@
 #load "core/std"
-use package core
+#import core {*}
 
 SomeNamespace :: struct {
     foo :: () {

--- a/tests/bugs/namespace_aliasing.onyx
+++ b/tests/bugs/namespace_aliasing.onyx
@@ -15,8 +15,9 @@ main :: (args) => {
     }
 
     {
-        use SomeNamespace;
+        // This is no longer a feature, and cannot be used anymore
+        //     use SomeNamespace;
 
-        foo();
+        SomeNamespace.foo();
     }
 }

--- a/tests/bugs/print_formatters.onyx
+++ b/tests/bugs/print_formatters.onyx
@@ -1,4 +1,5 @@
-use core
+#import core
+use core {printf}
 
 main :: () {
     printf("{\n");

--- a/tests/bugs/print_formatters.onyx
+++ b/tests/bugs/print_formatters.onyx
@@ -1,4 +1,4 @@
-#import core
+use core
 use core {printf}
 
 main :: () {

--- a/tests/caller_location.onyx
+++ b/tests/caller_location.onyx
@@ -1,6 +1,6 @@
 #load "core/std"
 
-#import core {*}
+use core {*}
 
 using_callsite :: (value: $T, site := #callsite) {
     println(value);
@@ -25,4 +25,4 @@ Something :: struct {
     }
 }
 
-#import runtime
+use runtime

--- a/tests/caller_location.onyx
+++ b/tests/caller_location.onyx
@@ -1,6 +1,6 @@
 #load "core/std"
 
-use package core
+#import core {*}
 
 using_callsite :: (value: $T, site := #callsite) {
     println(value);
@@ -25,4 +25,4 @@ Something :: struct {
     }
 }
 
-#local runtime :: package runtime
+#import runtime

--- a/tests/char_literals.onyx
+++ b/tests/char_literals.onyx
@@ -1,5 +1,4 @@
-#import core
-use core
+use core {*}
 
 
 main :: () {

--- a/tests/char_literals.onyx
+++ b/tests/char_literals.onyx
@@ -1,3 +1,4 @@
+#import core
 use core
 
 

--- a/tests/compile_time_procedures.onyx
+++ b/tests/compile_time_procedures.onyx
@@ -1,6 +1,6 @@
 #load "core/std"
 
-use package core
+#import core {*}
 
 Test_VTable :: struct {
     first  : (i32) -> i32;

--- a/tests/compile_time_procedures.onyx
+++ b/tests/compile_time_procedures.onyx
@@ -1,6 +1,6 @@
 #load "core/std"
 
-#import core {*}
+use core {*}
 
 Test_VTable :: struct {
     first  : (i32) -> i32;

--- a/tests/complicated_polymorph.onyx
+++ b/tests/complicated_polymorph.onyx
@@ -1,6 +1,6 @@
 #load "core/std"
 
-use package core
+#import core {*}
 
 main :: (args: [] cstr) {
     baked_proc :: (x: $T, $func: (T) -> typeof x) -> T {

--- a/tests/complicated_polymorph.onyx
+++ b/tests/complicated_polymorph.onyx
@@ -1,6 +1,6 @@
 #load "core/std"
 
-#import core {*}
+use core {*}
 
 main :: (args: [] cstr) {
     baked_proc :: (x: $T, $func: (T) -> typeof x) -> T {

--- a/tests/defer_with_continue.onyx
+++ b/tests/defer_with_continue.onyx
@@ -1,6 +1,6 @@
 #load "core/std"
 
-use package core
+#import core {*}
 
 main :: (args: [] cstr) {
     defer println("At the end!");

--- a/tests/defer_with_continue.onyx
+++ b/tests/defer_with_continue.onyx
@@ -1,6 +1,6 @@
 #load "core/std"
 
-#import core {*}
+use core {*}
 
 main :: (args: [] cstr) {
     defer println("At the end!");

--- a/tests/defined_test.onyx
+++ b/tests/defined_test.onyx
@@ -1,6 +1,6 @@
 #load "core/std"
 
-use package core
+#import core {*}
 
 main :: (args: [] cstr) {
     println(#defined(stdio));

--- a/tests/defined_test.onyx
+++ b/tests/defined_test.onyx
@@ -1,6 +1,6 @@
 #load "core/std"
 
-#import core {*}
+use core {*}
 
 main :: (args: [] cstr) {
     println(#defined(stdio));

--- a/tests/dyn_str.onyx
+++ b/tests/dyn_str.onyx
@@ -1,6 +1,6 @@
-#import core.string
-#import core.conv
-#import core
+use core.string
+use core.conv
+use core
 
 use core {
     println

--- a/tests/dyn_str.onyx
+++ b/tests/dyn_str.onyx
@@ -1,4 +1,10 @@
-use core
+#import core.string
+#import core.conv
+#import core
+
+use core {
+    println
+}
 
 
 main :: () {

--- a/tests/first_class_optional.onyx
+++ b/tests/first_class_optional.onyx
@@ -1,4 +1,5 @@
-use core
+#import core
+use core {println}
 
 foo :: (x: ?i32) -> i32 {
     return x? + 10;

--- a/tests/first_class_optional.onyx
+++ b/tests/first_class_optional.onyx
@@ -1,4 +1,4 @@
-#import core
+use core
 use core {println}
 
 foo :: (x: ?i32) -> i32 {

--- a/tests/float_parsing.onyx
+++ b/tests/float_parsing.onyx
@@ -1,6 +1,6 @@
 #load "core/std"
 
-#import core {*}
+use core {*}
 
 main :: (args: [] cstr) {
 

--- a/tests/float_parsing.onyx
+++ b/tests/float_parsing.onyx
@@ -1,6 +1,6 @@
 #load "core/std"
 
-use package core
+#import core {*}
 
 main :: (args: [] cstr) {
 

--- a/tests/hello_world.onyx
+++ b/tests/hello_world.onyx
@@ -2,8 +2,7 @@ package main
 
 #load "core/std"
 
-#import core
-use core
+use core {*}
 
 main :: (args: [] cstr) {
     println("Hello, World!");

--- a/tests/hello_world.onyx
+++ b/tests/hello_world.onyx
@@ -2,7 +2,8 @@ package main
 
 #load "core/std"
 
-use package core
+#import core
+use core
 
 main :: (args: [] cstr) {
     println("Hello, World!");

--- a/tests/i32map.onyx
+++ b/tests/i32map.onyx
@@ -2,7 +2,7 @@ package main
 
 #load "core/std"
 
-use package core
+#import core {*}
 
 main :: (args: [] cstr) {
     imap : Map(i32, str);

--- a/tests/i32map.onyx
+++ b/tests/i32map.onyx
@@ -2,7 +2,7 @@ package main
 
 #load "core/std"
 
-#import core {*}
+use core {*}
 
 main :: (args: [] cstr) {
     imap : Map(i32, str);

--- a/tests/if_expressions.onyx
+++ b/tests/if_expressions.onyx
@@ -1,7 +1,6 @@
 #load "core/std"
 
-#import core
-use core {println, printf}
+use core {package, println, printf}
 
 some_function :: () -> f32 {
     println("In some function!");

--- a/tests/if_expressions.onyx
+++ b/tests/if_expressions.onyx
@@ -1,6 +1,7 @@
 #load "core/std"
 
-use package core
+#import core
+use core {println, printf}
 
 some_function :: () -> f32 {
     println("In some function!");

--- a/tests/implicit_initialize_locals.onyx
+++ b/tests/implicit_initialize_locals.onyx
@@ -1,6 +1,6 @@
 #load "core/std"
 
-#import core {*}
+use core {*}
 
 main :: (args) => {
     {

--- a/tests/implicit_initialize_locals.onyx
+++ b/tests/implicit_initialize_locals.onyx
@@ -1,6 +1,6 @@
 #load "core/std"
 
-use package core
+#import core {*}
 
 main :: (args) => {
     {

--- a/tests/init_procedures.onyx
+++ b/tests/init_procedures.onyx
@@ -1,6 +1,6 @@
 #load "core/std"
 
-#import core {*}
+use core {*}
 
 first_init :: #init #after second_init () {
     println("In an #init proc.");

--- a/tests/init_procedures.onyx
+++ b/tests/init_procedures.onyx
@@ -1,6 +1,6 @@
 #load "core/std"
 
-use package core
+#import core {*}
 
 first_init :: #init #after second_init () {
     println("In an #init proc.");

--- a/tests/interfaces.onyx
+++ b/tests/interfaces.onyx
@@ -1,6 +1,12 @@
 #load "core/std"
 
-use package core
+#import core
+#import core.hash
+#import core.conv
+#import core.array
+#import core.iter
+
+use core {println, printf}
 
 Hashable :: interface (t :$T) {
     { hash.to_u32(t) } -> u32;

--- a/tests/interfaces.onyx
+++ b/tests/interfaces.onyx
@@ -1,10 +1,10 @@
 #load "core/std"
 
-#import core
-#import core.hash
-#import core.conv
-#import core.array
-#import core.iter
+use core
+use core.hash
+use core.conv
+use core.array
+use core.iter
 
 use core {println, printf}
 

--- a/tests/lazy_iterators.onyx
+++ b/tests/lazy_iterators.onyx
@@ -1,6 +1,6 @@
 #load "core/std"
 
-use package core
+#import core {*}
 
 count_iterator :: (lo: $T, hi: T, step: T = 1) -> Iterator(T) {
     return iter.generator(

--- a/tests/lazy_iterators.onyx
+++ b/tests/lazy_iterators.onyx
@@ -1,6 +1,6 @@
 #load "core/std"
 
-#import core {*}
+use core {*}
 
 count_iterator :: (lo: $T, hi: T, step: T = 1) -> Iterator(T) {
     return iter.generator(

--- a/tests/linked_lists.onyx
+++ b/tests/linked_lists.onyx
@@ -1,5 +1,5 @@
-#import core
-#import core.list
+use core
+use core.list
 
 use core {println}
 

--- a/tests/linked_lists.onyx
+++ b/tests/linked_lists.onyx
@@ -1,4 +1,7 @@
-use core
+#import core
+#import core.list
+
+use core {println}
 
 main :: () {
     l := list.make(i32);

--- a/tests/multiple_returns_robustness.onyx
+++ b/tests/multiple_returns_robustness.onyx
@@ -1,6 +1,7 @@
 #load "core/std"
 
-use package core
+#import core
+use core
 
 foo :: () -> (i32, i32) {
     return 50, 60;

--- a/tests/multiple_returns_robustness.onyx
+++ b/tests/multiple_returns_robustness.onyx
@@ -1,7 +1,6 @@
 #load "core/std"
 
-#import core
-use core
+use core {package, *}
 
 foo :: () -> (i32, i32) {
     return 50, 60;

--- a/tests/named_arguments_test.onyx
+++ b/tests/named_arguments_test.onyx
@@ -1,6 +1,6 @@
 #load "core/std"
 
-use package core
+#import core {*}
 
 main :: (args: [] cstr) {
     foo :: (x: i32, y: f32) {

--- a/tests/named_arguments_test.onyx
+++ b/tests/named_arguments_test.onyx
@@ -1,6 +1,6 @@
 #load "core/std"
 
-#import core {*}
+use core {*}
 
 main :: (args: [] cstr) {
     foo :: (x: i32, y: f32) {

--- a/tests/new_printf.onyx
+++ b/tests/new_printf.onyx
@@ -1,6 +1,6 @@
 #load "core/std"
 
-#import core {printf, map}
+use core {printf, map}
 
 main :: (args: [] cstr) {
     printf("{} {} {{}} {} {.1} {.5} {}\n", 123, "Test", false, 12.34, 12.3456789, [..] map.Map(i32, str));

--- a/tests/new_printf.onyx
+++ b/tests/new_printf.onyx
@@ -1,7 +1,7 @@
 #load "core/std"
 
-#import core
+#import core {printf, map}
 
 main :: (args: [] cstr) {
-    core.printf("{} {} {{}} {} {.1} {.5} {}\n", 123, "Test", false, 12.34, 12.3456789, [..] map.Map(i32, str));
+    printf("{} {} {{}} {} {.1} {.5} {}\n", 123, "Test", false, 12.34, 12.3456789, [..] map.Map(i32, str));
 }

--- a/tests/new_printf.onyx
+++ b/tests/new_printf.onyx
@@ -1,7 +1,7 @@
 #load "core/std"
 
-use package core
+#import core
 
 main :: (args: [] cstr) {
-    printf("{} {} {{}} {} {.1} {.5} {}\n", 123, "Test", false, 12.34, 12.3456789, [..] map.Map(i32, str));
+    core.printf("{} {} {{}} {} {.1} {.5} {}\n", 123, "Test", false, 12.34, 12.3456789, [..] map.Map(i32, str));
 }

--- a/tests/new_struct_behaviour.onyx
+++ b/tests/new_struct_behaviour.onyx
@@ -71,11 +71,12 @@ main :: (args: [] cstr) {
     {
         BasicallyANamespace.function_3();
 
-        use BasicallyANamespace;
-        function_2();
+        // TODO: Revisit this test case when `use struct` is added.
+        // use BasicallyANamespace;
+        BasicallyANamespace.function_2();
 
-        use SubNamespace;
-        function_4();
+        // use SubNamespace;
+        BasicallyANamespace.SubNamespace.function_4();
     }
 
 

--- a/tests/new_struct_behaviour.onyx
+++ b/tests/new_struct_behaviour.onyx
@@ -2,7 +2,7 @@
 
 #load "core/std"
 
-use package core
+#import core {*}
 
 
 Vec3 :: struct {

--- a/tests/new_struct_behaviour.onyx
+++ b/tests/new_struct_behaviour.onyx
@@ -2,7 +2,7 @@
 
 #load "core/std"
 
-#import core {*}
+use core {*}
 
 
 Vec3 :: struct {

--- a/tests/no_types.onyx
+++ b/tests/no_types.onyx
@@ -4,6 +4,7 @@
 
 #load "core/std"
 
+#import core
 use core
 
 main :: () {

--- a/tests/no_types.onyx
+++ b/tests/no_types.onyx
@@ -2,10 +2,7 @@
 // No types are written throughout this entire program.
 //
 
-#load "core/std"
-
-#import core
-use core
+use core {*}
 
 main :: () {
     object := .{

--- a/tests/operator_overload.onyx
+++ b/tests/operator_overload.onyx
@@ -1,6 +1,6 @@
 #load "core/std"
 
-#import core {*}
+use core {*}
 
 Complex :: struct {
     re : f32 = 0;

--- a/tests/operator_overload.onyx
+++ b/tests/operator_overload.onyx
@@ -1,6 +1,6 @@
 #load "core/std"
 
-use package core
+#import core {*}
 
 Complex :: struct {
     re : f32 = 0;

--- a/tests/osad_test.onyx
+++ b/tests/osad_test.onyx
@@ -1,5 +1,5 @@
-#import core
-#import core.encoding.osad
+use core
+use core.encoding.osad
 
 use core {printf}
 

--- a/tests/osad_test.onyx
+++ b/tests/osad_test.onyx
@@ -1,5 +1,7 @@
-use core
-use core.encoding {osad}
+#import core
+#import core.encoding.osad
+
+use core {printf}
 
 Foo :: struct {
     nums: [] i32;

--- a/tests/overload_precedence.onyx
+++ b/tests/overload_precedence.onyx
@@ -1,6 +1,6 @@
 #load "core/std"
 
-use package core
+#import core {*}
 
 overloaded :: #match {
     #order 10 (x: i32) { println("Option X"); },

--- a/tests/overload_precedence.onyx
+++ b/tests/overload_precedence.onyx
@@ -1,6 +1,6 @@
 #load "core/std"
 
-#import core {*}
+use core {*}
 
 overloaded :: #match {
     #order 10 (x: i32) { println("Option X"); },

--- a/tests/overload_return_type.onyx
+++ b/tests/overload_return_type.onyx
@@ -1,5 +1,5 @@
 
-#import core
+use core
 use core { println }
 
 main :: () {

--- a/tests/overload_return_type.onyx
+++ b/tests/overload_return_type.onyx
@@ -1,5 +1,6 @@
 
-use core
+#import core
+use core { println }
 
 main :: () {
     overloaded_proc(i32.{}) |> println();

--- a/tests/overload_with_autocast.onyx
+++ b/tests/overload_with_autocast.onyx
@@ -1,6 +1,7 @@
 #load "core/std"
 
-use package core
+#import core
+use core {println}
 
 overloaded :: #match {
     (x: str, y: i32) do println("Called str, i32"); ,

--- a/tests/overload_with_autocast.onyx
+++ b/tests/overload_with_autocast.onyx
@@ -1,6 +1,6 @@
 #load "core/std"
 
-#import core
+use core
 use core {println}
 
 overloaded :: #match {

--- a/tests/persist_locals.onyx
+++ b/tests/persist_locals.onyx
@@ -2,7 +2,7 @@
 
 #load "core/std"
 
-#import core {*}
+use core {*}
 
 
 main :: (args: [] cstr) {

--- a/tests/persist_locals.onyx
+++ b/tests/persist_locals.onyx
@@ -2,7 +2,7 @@
 
 #load "core/std"
 
-use package core
+#import core {*}
 
 
 main :: (args: [] cstr) {

--- a/tests/poly_struct_in_type_info.onyx
+++ b/tests/poly_struct_in_type_info.onyx
@@ -1,7 +1,7 @@
 #load "core/std"
 
-#import core {*}
-#import runtime.info
+use core {*}
+use runtime.info
 
 Base :: struct (T: type_expr) {
     const: i32;

--- a/tests/poly_struct_in_type_info.onyx
+++ b/tests/poly_struct_in_type_info.onyx
@@ -1,6 +1,7 @@
 #load "core/std"
-use package core
-info :: package runtime.info
+
+#import core {*}
+#import runtime.info
 
 Base :: struct (T: type_expr) {
     const: i32;

--- a/tests/poly_structs_with_values.onyx
+++ b/tests/poly_structs_with_values.onyx
@@ -1,6 +1,6 @@
 #load "core/std"
 
-use package core
+#import core {*}
 
 main :: (args: [] cstr) {
     NewPolyStruct :: struct (T: type_expr, N: i32) {

--- a/tests/poly_structs_with_values.onyx
+++ b/tests/poly_structs_with_values.onyx
@@ -1,6 +1,6 @@
 #load "core/std"
 
-#import core {*}
+use core {*}
 
 main :: (args: [] cstr) {
     NewPolyStruct :: struct (T: type_expr, N: i32) {

--- a/tests/polymorphic_array_lengths.onyx
+++ b/tests/polymorphic_array_lengths.onyx
@@ -1,6 +1,6 @@
 #load "core/std"
 
-#import core {*}
+use core {*}
 
 main :: (args: [] cstr) {
     arr := u32.[ 1, 2, 3, 4, 5 ];

--- a/tests/polymorphic_array_lengths.onyx
+++ b/tests/polymorphic_array_lengths.onyx
@@ -1,6 +1,6 @@
 #load "core/std"
 
-use package core
+#import core {*}
 
 main :: (args: [] cstr) {
     arr := u32.[ 1, 2, 3, 4, 5 ];

--- a/tests/remove_test.onyx
+++ b/tests/remove_test.onyx
@@ -1,6 +1,6 @@
 #load "core/std"
 
-#import core {*}
+use core {*}
 
 main :: (args) => {
     x: [..] i32;

--- a/tests/remove_test.onyx
+++ b/tests/remove_test.onyx
@@ -1,6 +1,6 @@
 #load "core/std"
 
-use package core
+#import core {*}
 
 main :: (args) => {
     x: [..] i32;

--- a/tests/sets.onyx
+++ b/tests/sets.onyx
@@ -1,6 +1,6 @@
 #load "core/std"
 
-#import core {*}
+use core {*}
 
 main :: (args: [] cstr) {
 

--- a/tests/sets.onyx
+++ b/tests/sets.onyx
@@ -1,6 +1,6 @@
 #load "core/std"
 
-use package core
+#import core {*}
 
 main :: (args: [] cstr) {
 

--- a/tests/stdlib/base64.onyx
+++ b/tests/stdlib/base64.onyx
@@ -1,4 +1,5 @@
-use core.encoding
+#import core
+#import core.encoding.base64
 
 decode_test :: () {
     for .[

--- a/tests/stdlib/base64.onyx
+++ b/tests/stdlib/base64.onyx
@@ -1,5 +1,5 @@
-#import core
-#import core.encoding.base64
+use core
+use core.encoding.base64
 
 decode_test :: () {
     for .[

--- a/tests/string_stream_test.onyx
+++ b/tests/string_stream_test.onyx
@@ -1,6 +1,8 @@
 #load "core/std"
 
-use package core
+#import core
+#import core.io
+use core {println}
 
 main :: (args: [] cstr) {
     some_string := "This is a test string that can be read.\n\n\n\n\n\n1234 4567";

--- a/tests/string_stream_test.onyx
+++ b/tests/string_stream_test.onyx
@@ -1,7 +1,7 @@
 #load "core/std"
 
-#import core
-#import core.io
+use core
+use core.io
 use core {println}
 
 main :: (args: [] cstr) {

--- a/tests/struct_robustness.onyx
+++ b/tests/struct_robustness.onyx
@@ -1,6 +1,6 @@
 #load "core/std"
 
-#import core {*}
+use core {*}
 
 main :: (args: [] cstr) {
 

--- a/tests/struct_robustness.onyx
+++ b/tests/struct_robustness.onyx
@@ -26,11 +26,10 @@ main :: (args: [] cstr) {
 
         ss: SimpleStruct = SimpleStruct.{ 41, 67, "Steve" };
 
-        use ss;
         printf("SimpleStruct<{}, {}>({}, {}, {})\n",
             sizeof SimpleStruct,
             alignof SimpleStruct,
-            cast(u32) age, height, name);
+            cast(u32) ss.age, ss.height, ss.name);
     }
 
     test_simple_union :: () {

--- a/tests/struct_robustness.onyx
+++ b/tests/struct_robustness.onyx
@@ -1,6 +1,6 @@
 #load "core/std"
 
-use package core
+#import core {*}
 
 main :: (args: [] cstr) {
 

--- a/tests/struct_use_pointer_member.onyx
+++ b/tests/struct_use_pointer_member.onyx
@@ -1,5 +1,5 @@
 #load "core/std"
-use package core
+#import core {*}
 
 Person_Vtable :: struct {
     greet: (&Person) -> void;

--- a/tests/struct_use_pointer_member.onyx
+++ b/tests/struct_use_pointer_member.onyx
@@ -1,5 +1,5 @@
 #load "core/std"
-#import core {*}
+use core {*}
 
 Person_Vtable :: struct {
     greet: (&Person) -> void;

--- a/tests/switch_using_equals.onyx
+++ b/tests/switch_using_equals.onyx
@@ -1,6 +1,6 @@
 #load "core/std"
 
-use package core
+#import core {*}
 
 Vector2 :: struct { x, y: i32; }
 #operator == macro (v1: Vector2, v2: Vector2) => v1.x == v2.x && v1.y == v2.y;

--- a/tests/switch_using_equals.onyx
+++ b/tests/switch_using_equals.onyx
@@ -1,6 +1,6 @@
 #load "core/std"
 
-#import core {*}
+use core {*}
 
 Vector2 :: struct { x, y: i32; }
 #operator == macro (v1: Vector2, v2: Vector2) => v1.x == v2.x && v1.y == v2.y;

--- a/tests/utf8_test.onyx
+++ b/tests/utf8_test.onyx
@@ -1,6 +1,6 @@
-#import core
-#import core.encoding.utf8
-#import runtime
+use core
+use core.encoding.utf8
+use runtime
 
 use core {print, println, printf}
 

--- a/tests/utf8_test.onyx
+++ b/tests/utf8_test.onyx
@@ -1,5 +1,8 @@
-use core
-use core.encoding {utf8}
+#import core
+#import core.encoding.utf8
+#import runtime
+
+use core {print, println, printf}
 
 #inject runtime.vars.Enable_Heap_Debug :: true
 

--- a/tests/vararg_test.onyx
+++ b/tests/vararg_test.onyx
@@ -2,7 +2,7 @@ package main
 
 #load "core/std"
 
-use package core;
+#import core {*};
 
 old_va_test :: (prefix: str, va: ..i32) {
     println(prefix);

--- a/tests/vararg_test.onyx
+++ b/tests/vararg_test.onyx
@@ -2,7 +2,7 @@ package main
 
 #load "core/std"
 
-#import core {*};
+use core {*};
 
 old_va_test :: (prefix: str, va: ..i32) {
     println(prefix);


### PR DESCRIPTION
As of right now, there is no way to specify which packages a file will use. Currently, top-level packages, like `builtin` and `core` are accessible directly in the global scope. This has been fine, but I anticipate issues when projects scale and not all packages are develop by one person. For this reason, I think a "real" import system will be beneficial.

The basic idea is as follows. If you want to access the `core` package, simply `#import core`. This makes the `core` symbol at the file scope be the `core` package. From there you can access the sub-packages of `core` directly, without needing to `#import` them.

If you want to import all public symbols of `core`, equivalent of `use core` now, you would do `#import core {*}`.

If you want some symbols of `core`, use `#import core {array, string}`

If you want to alias the imported symbols from core use `#import core {A :: array, S :: string}`