### PR TITLE
Update `Try Online` link on README to try.onyxlang.io

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,5 +5,5 @@
 
 A simple, yet powerful language for WebAssembly.
 
-[Try Online](https://onyxlang.io/playground/) |
+[Try Online](https://try.onyxlang.io/) |
 [Read the Docs](https://onyxlang.io/docs/)


### PR DESCRIPTION
Great works! 
I read [the article on Wasmer blog](https://wasmer.io/posts/onyxlang-powered-by-wasmer) and get excited to image how this new language will be used.

I found 404 page for [Try Online](https://onyxlang.io/playground/) link on the front README, which seemingly is an old one, so just replaced it to https://try.onyxlang.io/ .