### PR TITLE
Update instance.c to fix build error

### DIFF
--- a/interpreter/src/wasm/instance.c
+++ b/interpreter/src/wasm/instance.c
@@ -4,7 +4,7 @@
 #include "vm.h"
 #include <alloca.h>
 
-static_assert(sizeof(ovm_value_t) == sizeof(wasm_val_t));
+static_assert(sizeof(ovm_value_t) == sizeof(wasm_val_t), "Size of ovm_value_t should match size of wasm_val_t");
 
 typedef struct wasm_ovm_binding wasm_ovm_binding;
 struct wasm_ovm_binding {


### PR DESCRIPTION
I was not able to build the project due to the following error

```
src/wasm/instance.c:7:56: error: expected ‘,’ before ‘)’ token
 static_assert(sizeof(ovm_value_t) == sizeof(wasm_val_t));
```

Providing a debug message to the `static_assert` resolved the issue.