### PR TITLE
Fix failing onyx_runtime build on darwin

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,3 +24,5 @@ bin/onyx
 releases/
 compiler/onyx
 runtime/onyx_runtime.so
+runtime/onyx_runtime.dylib
+runtime/onyx_runtime.dll

--- a/runtime/onyx_runtime.c
+++ b/runtime/onyx_runtime.c
@@ -29,6 +29,10 @@
     #include <linux/futex.h>
 #endif
 
+#if defined(_BH_DARWIN)
+    #include <Security/Security.h>
+#endif
+
 #include "types.h"  // For POINTER_SIZE
 
 #include "src/ort_files.h"


### PR DESCRIPTION
Compiler build from source on mac would fail in `ort_os.h` due to a call to `SecRandomCopyBytes`. 