### PR TITLE
Handle unary expressions when building array types; disallow negative array sizes; add test

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 **/*.o
+**/*.DS_Store
 *.o
 tags
 *.wasm

--- a/tests/bugs/array_lengths.onyx
+++ b/tests/bugs/array_lengths.onyx
@@ -1,0 +1,29 @@
+#load "core/module"
+
+use core { * }
+
+An_Enum :: enum {
+   A;
+   B;
+   C;
+   D;
+
+   Count;
+}
+
+A_Struct :: struct {
+   a: i32;
+   b: i32;
+   c: i32;
+}
+
+main :: () {
+   arr1: [cast(i32)(3 * 4 - 5)]f32;
+   arr2: [cast(i32)An_Enum.Count]A_Struct;
+
+   assert(arr1.count == (3 * 4 - 5), "invalid count for arr1");
+   assert(sizeof(typeof(arr1)) == (3 * 4 - 5) * sizeof(f32), "invalid size for arr1");
+
+   assert(arr2.count == ~~An_Enum.Count, "invalid count for arr2");
+   assert(sizeof(typeof(arr2)) == ~~An_Enum.Count * sizeof(A_Struct), "invalid size for arr2");
+}


### PR DESCRIPTION
This PR fixes #52 by handling integer unary expressions within `get_expression_integer_value`. It also disallows negative integer array sizes.