### PR TITLE
Add onyx.tmPreferences for Sublime Text comment support

### DIFF
--- a/misc/onyx.tmPreferences
+++ b/misc/onyx.tmPreferences
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple Computer//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+  <key>name</key>
+  <string>Comments</string>
+  <key>scope</key>
+  <string>source.onyx</string>
+  <key>settings</key>
+  <dict>
+    <key>shellVariables</key>
+    <array>
+      <dict>
+        <key>name</key>
+        <string>TM_COMMENT_START</string>
+        <key>value</key>
+        <string>// </string>
+      </dict>
+    </array>
+  </dict>
+</dict>
+</plist>


### PR DESCRIPTION
Sublime Text won't allow you to comment code via the shortcut unless a tmPreferences file exists. This PR adds that file so people don't have to create it manually. 