### PR TITLE
Improve non-const array size error

### DIFF
--- a/compiler/src/types.c
+++ b/compiler/src/types.c
@@ -383,7 +383,7 @@ static Type* type_build_from_ast_inner(bh_allocator alloc, AstType* type_node, b
 
                 if (!valid) {
                     if (!(a_node->count_expr->flags & Ast_Flag_Const)) {
-                        onyx_report_error(a_node->token->pos, Error_Critical, "Array type size must be a constant expression.");
+                        onyx_report_error(a_node->token->pos, Error_Critical, "Array type size must be a constant.");
                     }
                     else {
                         onyx_report_error(a_node->token->pos, Error_Critical, "Array type size expression must be 'i32', got '%s'.",

--- a/compiler/src/types.c
+++ b/compiler/src/types.c
@@ -382,8 +382,14 @@ static Type* type_build_from_ast_inner(bh_allocator alloc, AstType* type_node, b
                 count = get_expression_integer_value(a_node->count_expr, &valid);
 
                 if (!valid) {
-                    onyx_report_error(a_node->token->pos, Error_Critical, "Array type size expression must be 'i32', got '%s'.",
-                        type_get_name(a_node->count_expr->type));
+                    if (!(a_node->count_expr->flags & Ast_Flag_Const)) {
+                        onyx_report_error(a_node->token->pos, Error_Critical, "Array type size must be a constant expression.");
+                    }
+                    else {
+                        onyx_report_error(a_node->token->pos, Error_Critical, "Array type size expression must be 'i32', got '%s'.",
+                            type_get_name(a_node->count_expr->type));
+                    }
+
                     return NULL;
                 }
 

--- a/compiler/src/types.c
+++ b/compiler/src/types.c
@@ -382,7 +382,7 @@ static Type* type_build_from_ast_inner(bh_allocator alloc, AstType* type_node, b
                 count = get_expression_integer_value(a_node->count_expr, &valid);
 
                 if (!valid) {
-                    if (!(a_node->count_expr->flags & Ast_Flag_Const)) {
+                    if (!(a_node->count_expr->flags & Ast_Flag_Comptime)) {
                         onyx_report_error(a_node->token->pos, Error_Critical, "Array type size must be a constant.");
                     }
                     else {


### PR DESCRIPTION
This PR improves the error message around using non-constant expression as the array size.

Before:

```odin
main :: () {
    size := 10;
    arr: [size] u32; // Array type size expression must be 'i32', got 'i32'.
}
``` 

After:
```odin
main :: () {
    size := 10;
    arr: [size] u32; // Array type size must be a constant.
}
```