### PR TITLE
Fixed the help subcommand to return the correct exit status upon execution

### DIFF
--- a/compiler/src/onyx.c
+++ b/compiler/src/onyx.c
@@ -1175,7 +1175,7 @@ int main(int argc, char *argv[]) {
             } else {
                 bh_printf(top_level_docstring);
             }
-            return 1;
+            return 0;
         }
 
         case ONYX_COMPILE_ACTION_PRINT_VERSION: {


### PR DESCRIPTION
This PR addresses issue #71 by fixing the exit status for the 'help' subcommand.