### PR TITLE
Feature: Implementing help as a subcommand for other subcommands.

### DIFF
--- a/compiler/src/onyx.c
+++ b/compiler/src/onyx.c
@@ -187,6 +187,12 @@ static CompileOptions compile_opts_parse(bh_allocator alloc, int argc, char *arg
     bh_arr_push(options.included_folders, ".");
 
     if (argc == 1) return options;
+    if (argc == 3) {
+        if (!strcmp(argv[2], "help")) {
+            options.help_subcommand = argv[1];
+            goto skip_parsing_arguments;
+        }
+    }
     i32 arg_parse_start = 1;
 
     if (!strcmp(argv[1], "help")) {


### PR DESCRIPTION
It's become quite the norm in many cli applications (compilers, etc) to not only present the help section by typing, for example, "onyx help build" but also by appending help to the subcommand you're looking into.

This simple fix will present the relevant help-section by either doing "onyx help build" or "onyx build help".

Could probably be done in a better way to enable putting help after certain, more complex, flags that might need their own detailed help section.