### PR TITLE
Added: `///` for doc comments

### DIFF
--- a/compiler/include/astnodes.h
+++ b/compiler/include/astnodes.h
@@ -1145,16 +1145,24 @@ struct AstDistinctType {
 };
 
 // Top level nodes
-struct AstBinding       { AstTyped_base; AstNode* node; OnyxToken *documentation; };
 struct AstAlias         { AstTyped_base; AstTyped* alias; };
 struct AstInclude       { AstNode_base;  AstTyped* name_node; char* name; b32 recursive: 1; };
+struct AstBinding       {
+    AstTyped_base;
+    AstNode* node;
+
+    // Used for the old '#doc' scheme
+    OnyxToken *documentation_token_old;
+
+    // Used for the new `///` scheme
+    const char *documentation_string;
+};
 struct AstInjection     {
     AstTyped_base;
     AstTyped* full_loc;
-    AstTyped* to_inject;
     AstTyped* dest;
     OnyxToken *symbol;
-    OnyxToken *documentation;
+    AstBinding *binding;
 };
 struct AstMemRes        {
     AstTyped_base;
@@ -1786,7 +1794,9 @@ struct Package {
     bh_arr(Entity *) use_package_entities;
 
     // NOTE: This tracks all #package_doc statements used for this package.
-    bh_arr(OnyxToken *) doc_strings;
+    bh_arr(OnyxToken *) doc_string_tokens;
+
+    bh_arr(const char *) doc_strings;
 
     // NOTE: These are entities that are stored in packages marked with `#allow_stale_code`.
     // These entities are flushed to the entity heap when the package has been explicit used
@@ -2159,7 +2169,7 @@ b32 resolve_intrinsic_interface_constraint(AstConstraint *constraint);
 void track_declaration_for_tags(AstNode *);
 
 void track_declaration_for_symbol_info(OnyxFilePos, AstNode *);
-void track_documentation_for_symbol_info(AstNode *, OnyxToken *);
+void track_documentation_for_symbol_info(AstNode *, AstBinding *);
 void track_resolution_for_symbol_info(AstNode *original, AstNode *resolved);
 
 // NOTE: Useful inlined functions

--- a/compiler/include/doc.h
+++ b/compiler/include/doc.h
@@ -24,7 +24,8 @@ struct SymbolInfo {
 	u32 file_id;
 	u32 line;
 	u32 column;
-	OnyxToken *documentation;
+	const char *documentation;
+	u32 documentation_length;
 };
 
 typedef struct SymbolResolution SymbolResolution;

--- a/compiler/include/lex.h
+++ b/compiler/include/lex.h
@@ -87,6 +87,8 @@ typedef enum TokenType {
 
     Token_Type_Inserted_Semicolon,
 
+    Token_Type_Doc_Comment,
+
     Token_Type_Count,
 } TokenType;
 

--- a/compiler/include/parser.h
+++ b/compiler/include/parser.h
@@ -49,8 +49,11 @@ typedef struct OnyxParser {
 
     // Used by `#doc` directives to store their documentation
     // string. This is then used by binding nodes to capture
-    // documentation.
+    // documentation. DEPRECATED
     OnyxToken *last_documentation_token;
+
+    // Used by `///` doc comments
+    bh_arr(OnyxToken *) documentation_tokens;
 
     u16 tag_depth : 16;
 

--- a/compiler/src/checker.c
+++ b/compiler/src/checker.c
@@ -3794,10 +3794,8 @@ CheckStatus check_process_directive(AstNode* directive) {
             YIELD_ERROR(inject->token->pos, "Cannot #inject here.");
         }
 
-        AstBinding *binding = onyx_ast_node_new(context.ast_alloc, sizeof(AstBinding), Ast_Kind_Binding);
-        binding->token = inject->symbol;
-        binding->node = (AstNode *) inject->to_inject;
-        binding->documentation = inject->documentation;
+        // Check if this line is even necessary
+        inject->binding->token = inject->symbol;
 
         Package *pac = NULL;
         if (inject->dest->kind == Ast_Kind_Package) {
@@ -3806,7 +3804,7 @@ CheckStatus check_process_directive(AstNode* directive) {
             pac = context.checker.current_entity->package;
         }
 
-        add_entities_for_node(NULL, (AstNode *) binding, scope, pac);
+        add_entities_for_node(NULL, (AstNode *) inject->binding, scope, pac);
         return Check_Complete;
     }
 

--- a/compiler/src/lex.c
+++ b/compiler/src/lex.c
@@ -4,10 +4,10 @@
 #include "errors.h"
 
 static const char* token_type_names[] = {
-    "TOKEN_TYPE_UNKNOWN",
-    "TOKEN_TYPE_END_STREAM",
+    "UNKNOWN",
+    "the end of file",
 
-    "TOKEN_TYPE_COMMENT",
+    "a comment",
 
     "", // start
     "package",
@@ -67,19 +67,21 @@ static const char* token_type_names[] = {
     ">>=",
     ">>>=",
     "..",
-    "..="
+    "..=",
     "~~",
     "??",
 
-    "TOKEN_TYPE_SYMBOL",
-    "TOKEN_TYPE_LITERAL_STRING",
-    "TOKEN_TYPE_LITERAL_CHAR",
-    "TOKEN_TYPE_LITERAL_INTEGER",
-    "TOKEN_TYPE_LITERAL_FLOAT",
+    "a symbol",
+    "a string",
+    "a character literal",
+    "an integer",
+    "a float",
     "true",
     "false",
 
-    "inserted semicolon",
+    "an inserted semicolon",
+
+    "a doc comment",
 
     "TOKEN_TYPE_COUNT"
 };
@@ -212,14 +214,22 @@ whitespace_skipped:
     // Comments
     if (*tokenizer->curr == '/' && *(tokenizer->curr + 1) == '/') {
         tokenizer->curr += 2;
-        tk.type = Token_Type_Comment;
+
+        if (*tokenizer->curr == '/') {
+            tokenizer->curr += 1;
+            tk.type = Token_Type_Doc_Comment;
+        } else {
+            tk.type = Token_Type_Comment;
+        }
+
         tk.text = tokenizer->curr;
+        tk.pos.column = (u16)(tokenizer->curr - tokenizer->line_start) + 1;
 
         while (*tokenizer->curr != '\n' && tokenizer->curr != tokenizer->end) {
             INCREMENT_CURR_TOKEN(tokenizer);
         }
 
-        tk.length = tokenizer->curr - tk.text - 2;
+        tk.length = tokenizer->curr - tk.text;
 
         if (bh_arr_length(tokenizer->tokens) == 0 && bh_str_starts_with(tk.text, "+optional-semicolons")) {
             tokenizer->optional_semicolons = 1;
@@ -440,7 +450,7 @@ whitespace_skipped:
 
     case '<':
         LITERAL_TOKEN("<=",          0, Token_Type_Less_Equal);
-        LITERAL_TOKEN("<-",          0, Token_Type_Right_Arrow);
+        LITERAL_TOKEN("<-",          0, Token_Type_Left_Arrow);
         LITERAL_TOKEN("<<=",         0, Token_Type_Shl_Equal);
         LITERAL_TOKEN("<<",          0, Token_Type_Shift_Left);
         break;

--- a/compiler/src/symres.c
+++ b/compiler/src/symres.c
@@ -1665,7 +1665,7 @@ static SymresStatus symres_process_directive(AstNode* directive) {
             }
 
             SYMRES(expression, &inject->dest);
-            SYMRES(expression, &inject->to_inject);
+            // SYMRES(expression, &inject->to_inject);
             break;
         }
 
@@ -1964,7 +1964,7 @@ void symres_entity(Entity* ent) {
     switch (ent->type) {
         case Entity_Type_Binding: {
             symbol_introduce(current_scope, ent->binding->token, ent->binding->node);
-            track_documentation_for_symbol_info(ent->binding->node, ent->binding->documentation);
+            track_documentation_for_symbol_info(ent->binding->node, ent->binding);
             track_declaration_for_tags((AstNode *) ent->binding);
 
             if (context.doc_info) {

--- a/compiler/src/utils.c
+++ b/compiler/src/utils.c
@@ -1686,7 +1686,7 @@ void track_declaration_for_symbol_info(OnyxFilePos pos, AstNode *node) {
     bh_imap_put(&syminfo->node_to_id, (u64) node, (u64) symbol_id);
 }
 
-void track_documentation_for_symbol_info(AstNode *node, OnyxToken *documentation) {
+void track_documentation_for_symbol_info(AstNode *node, AstBinding *binding) {
     if (!context.options->generate_lsp_info_file) return;
     if (!context.options->generate_symbol_info_file) return;
 
@@ -1696,7 +1696,14 @@ void track_documentation_for_symbol_info(AstNode *node, OnyxToken *documentation
     if (!bh_imap_has(&syminfo->node_to_id, (u64) node)) return;
 
     u64 symbol_id = bh_imap_get(&syminfo->node_to_id, (u64) node);
-    syminfo->symbols[symbol_id].documentation = documentation;
+    if (binding->documentation_token_old) {
+        syminfo->symbols[symbol_id].documentation        = binding->documentation_token_old->text;
+        syminfo->symbols[symbol_id].documentation_length = binding->documentation_token_old->length;
+    } else {
+        assert(binding->documentation_string);
+        syminfo->symbols[symbol_id].documentation = binding->documentation_string;
+        syminfo->symbols[symbol_id].documentation_length = strlen(binding->documentation_string);
+    }
 }
 
 void track_resolution_for_symbol_info(AstNode *original, AstNode *resolved) {

--- a/core/alloc/alloc.onyx
+++ b/core/alloc/alloc.onyx
@@ -13,16 +13,14 @@ package core.alloc
 use core.memory
 use core.intrinsics.types {type_is_function}
 
-#doc "Overloaded procedure for converting something to an Allocator."
+/// Overloaded procedure for converting something to an Allocator.
 as_allocator :: #match {
     macro (a: Allocator) => a
 }
 
-#doc """
-    Allocates memory from the stack. This is similar to `alloca` in C.
-
-    **DO NOT USE THIS IN A LOOP! You cannot free memory allocated off the stack.**
-"""
+/// Allocates memory from the stack. This is similar to `alloca` in C.
+///
+/// **DO NOT USE THIS IN A LOOP! You cannot free memory allocated off the stack.**
 from_stack :: macro (size: u32) -> rawptr {
     // This should do something about the alignment...
     // Everything so far has assume that the stack is aligned to 16 bytes.
@@ -30,26 +28,22 @@ from_stack :: macro (size: u32) -> rawptr {
     return __stack_top;
 }
 
-#doc """
-    Allocates memory from the stack to form a slice of `T` with length `size`.
-
-    **DO NOT USE THIS IN A LOOP! You cannot free memory allocated off the stack.**
-"""
+/// Allocates memory from the stack to form a slice of `T` with length `size`.
+///
+/// **DO NOT USE THIS IN A LOOP! You cannot free memory allocated off the stack.**
 array_from_stack :: macro ($T: type_expr, size: u32) -> [] T {
     defer __stack_top = cast([&]u8, __stack_top) + size * sizeof T;
     return (cast([&]T) __stack_top)[0 .. size];
 }
 
-#doc """
-    Moves a value on to the heap. Useful for cases like this in
-
-        f :: () -> &Foo {
-            return alloc.on_heap(Foo.{
-                name = "...",
-                age  = 42
-            });
-        }
-"""
+/// Moves a value on to the heap. Useful for cases like this in
+///
+///     f :: () -> &Foo {
+///         return alloc.on_heap(Foo.{
+///             name = "...",
+///             age  = 42
+///         });
+///     }
 on_heap :: macro (v: $V) -> &V {
     use core
 
@@ -59,9 +53,7 @@ on_heap :: macro (v: $V) -> &V {
     return out;
 }
 
-#doc """
-    Like `alloc.on_heap`, but allocates on the temporary allocator.
-"""
+/// Like `alloc.on_heap`, but allocates on the temporary allocator.
 on_temp :: macro (v: $V) -> &V {
     use core
 
@@ -71,10 +63,8 @@ on_temp :: macro (v: $V) -> &V {
     return out;
 }
 
-#doc """
-    Copies the internal closure data of a function to the provided allocator,
-    and returns the new closed function.
-"""
+/// Copies the internal closure data of a function to the provided allocator,
+/// and returns the new closed function.
 copy_closure :: (f: $F/type_is_function, a: Allocator) -> F {
     if !f.closure do return f;
 
@@ -99,19 +89,15 @@ temp_state     : arena.ArenaState;
 #thread_local
 temp_allocator : Allocator;
 
-#doc """
-    Initializes the thread-local temporary allocator.
-
-    You do not need to call this. It is called automatically on thread initialization.
-"""
+/// Initializes the thread-local temporary allocator.
+///
+/// You do not need to call this. It is called automatically on thread initialization.
 init_temp_allocator :: () {
     temp_state = arena.make(heap_allocator, TEMPORARY_ALLOCATOR_SIZE);
     temp_allocator = as_allocator(&temp_state);
 }
 
-#doc """
-    Resets the temporary allocator, effectively freeing all allocations made in the temporary allocator.
-"""
+/// Resets the temporary allocator, effectively freeing all allocations made in the temporary allocator.
 clear_temp_allocator :: () {
     arena.clear(&temp_state);
 }

--- a/core/alloc/arena.onyx
+++ b/core/alloc/arena.onyx
@@ -1,27 +1,23 @@
+/// This allocator is mostly used for making many fixed-size
+/// allocation (i.e. allocations that will not need to change
+/// in size, such as game entities or position structs). The
+/// power of this allocator over the heap allocator for this
+/// purpose is that it is much faster, since the logic is
+/// simpler. Another power of this allocator over something
+/// such as a dynamic array is that the dynamic array could
+/// relocate and cause any pointers to the data inside to
+/// become invalidated; this is definitely not behaviour you
+/// want. This arena allocator can grow as large as needed,
+/// while guaranteeing that the memory inside of it will
+/// never move.
 package core.alloc.arena
-#package_doc """
-    This allocator is mostly used for making many fixed-size
-    allocation (i.e. allocations that will not need to change
-    in size, such as game entities or position structs). The
-    power of this allocator over the heap allocator for this
-    purpose is that it is much faster, since the logic is
-    simpler. Another power of this allocator over something
-    such as a dynamic array is that the dynamic array could
-    relocate and cause any pointers to the data inside to
-    become invalidated; this is definitely not behaviour you
-    want. This arena allocator can grow as large as needed,
-    while guaranteeing that the memory inside of it will
-    never move.
-"""
 
 use core
 
 // Deprecated struct 'ArenaState'. Use 'Arena' instead.
 ArenaState :: Arena
 
-#doc """
-    Stores internal details used during arena allocations.
-"""
+/// Stores internal details used during arena allocations.
 Arena :: struct {
     backing_allocator : Allocator;
 
@@ -94,12 +90,10 @@ arena_alloc_proc :: (data: rawptr, aa: AllocationAction, size: u32, align: u32, 
     return null;
 }
 
-#doc """
-    Makes a new arena.
-
-    `arena_size` specifies the size of each individual arena page, which must be at least 4 bytes
-    in size (but should be quite a bit large).
-"""
+/// Makes a new arena.
+///
+/// `arena_size` specifies the size of each individual arena page, which must be at least 4 bytes
+/// in size (but should be quite a bit large).
 make :: (backing: Allocator, arena_size: u32) -> Arena {
     assert(arena_size >= 4, "Arena size was expected to be at least 4 bytes.");
     
@@ -124,9 +118,7 @@ make_allocator :: (rs: &Arena) -> Allocator {
     };
 }
 
-#doc """
-    Frees all pages in an arena.
-"""
+/// Frees all pages in an arena.
 free :: (arena: &Arena) {
     walker := arena.first_arena;
     trailer := walker;
@@ -141,9 +133,7 @@ free :: (arena: &Arena) {
     arena.size          = 0;
 }
 
-#doc """
-    Clears and frees every page, except for first page.
-"""
+/// Clears and frees every page, except for first page.
 clear :: (arena: &Arena) {
     walker := arena.first_arena.next;
 
@@ -157,9 +147,7 @@ clear :: (arena: &Arena) {
     arena.size = sizeof rawptr;
 }
 
-#doc """
-    Returns the number of pages in the arena.
-"""
+/// Returns the number of pages in the arena.
 get_allocated_arenas :: (arena: &Arena) -> u32 {
     arenas := 0;
     walker := arena.first_arena;
@@ -171,27 +159,23 @@ get_allocated_arenas :: (arena: &Arena) -> u32 {
     return arenas;
 }
 
-#doc """
-    Returns the number of bytes used by the arena.
-"""
+/// Returns the number of bytes used by the arena.
 get_allocated_bytes :: (arena: &Arena) -> u32 {
     return get_allocated_arenas(arena) * (arena.arena_size - 1) + arena.size;
 }
 
-#doc """
-    Creates an arena allocator and automatically applies it to the context's allocator
-    in the current scope.
-
-        foo :: () {
-            alloc.arena.auto();
-
-            // Lazily allocate everything, knowing that it will
-            // be freed when this function returns.
-            for 100 {
-                s := string.copy("Make a copy of me!");
-            }
-        }
-"""
+/// Creates an arena allocator and automatically applies it to the context's allocator
+/// in the current scope.
+///
+///     foo :: () {
+///         alloc.arena.auto();
+///     
+///         // Lazily allocate everything, knowing that it will
+///         // be freed when this function returns.
+///         for 100 {
+///             s := string.copy("Make a copy of me!");
+///         }
+///     }
 auto :: #match {
     macro (size := 32 * 1024, $dest: Code = [](context.allocator)) {
         use core.alloc {arena, heap_allocator}
@@ -217,19 +201,17 @@ auto :: #match {
     }
 }
 
-#doc """
-    Creates an arena allocator to be used as the temporary allocator
-    in the code block.
-
-        foo :: () {
-            alloc.arena.auto_temp() {
-                for 1000 {
-                    // Will be automatically freed
-                    x := new_temp(i32);
-                }
-            }
-        }
-"""
+/// Creates an arena allocator to be used as the temporary allocator
+/// in the code block.
+///
+///     foo :: () {
+///         alloc.arena.auto_temp() {
+///             for 1000 {
+///                 // Will be automatically freed
+///                 x := new_temp(i32);
+///             }
+///         }
+///     }
 auto_temp :: macro (body: Code) -> i32 {
     use core.alloc {arena, heap_allocator}
     a := arena.make(heap_allocator, 32 * 1024);

--- a/core/alloc/atomic.onyx
+++ b/core/alloc/atomic.onyx
@@ -1,10 +1,8 @@
+/// AtomicAllocator wraps another allocator in a mutex, 
+/// ensuring that every allocation is thread-safe. This 
+/// is not needed for the general purpose heap allocator, 
+/// as that already has a thread-safe implementation.
 package core.alloc.atomic
-#package_doc """
-    AtomicAllocator wraps another allocator in a mutex, 
-    ensuring that every allocation is thread-safe. This 
-    is not needed for the general purpose heap allocator, 
-    as that already has a thread-safe implementation.
-"""
 
 // This can only be used when the core.sync package exists.
 #if #defined(package core.sync) {
@@ -13,19 +11,15 @@ package core.alloc.atomic
 use core.alloc
 use core.sync
 
-#doc """
-    Stores internal details used by the atomic allocator.
-
-    Simply the wrapped allocator and the mutex.
-"""
+/// Stores internal details used by the atomic allocator.
+///
+/// Simply the wrapped allocator and the mutex.
 AtomicAllocator :: struct {
     a: Allocator;
     m: sync.Mutex;
 }
 
-#doc """
-    Creates a new AtomicAllocator over an existing allocator.
-"""
+/// Creates a new AtomicAllocator over an existing allocator.
 make :: (a: Allocator) -> AtomicAllocator {
     atomic: AtomicAllocator = .{ a = a };
 
@@ -34,9 +28,7 @@ make :: (a: Allocator) -> AtomicAllocator {
     return atomic;
 }
 
-#doc """
-    Makes an allocator out of the atomic allocator state.
-"""
+/// Makes an allocator out of the atomic allocator state.
 make_allocator :: (atomic: &AtomicAllocator) =>
     Allocator.{ atomic, atomic_alloc };
 

--- a/core/alloc/fixed.onyx
+++ b/core/alloc/fixed.onyx
@@ -1,16 +1,14 @@
+/// This allocator is very simple. It is simply a bump allocator from
+/// a fixed size buffer. It cannot free or resize, and will return null
+/// when it has used all memory in the buffer given to it.
+/// 
+/// This kind of allocator is useful for temporary string building or
+/// similar circumstances, where you know that the needed memory size
+/// will not be exceeded, but you don't what to deal with potential
+/// slowness of a general heap allocator. By using this allocator, you
+/// can continue to use the same code that does allocations like normal,
+/// but can get the speed increase of a simple allocation strategy.
 package core.alloc.fixed
-#package_doc """
-    This allocator is very simple. It is simply a bump allocator from
-    a fixed size buffer. It cannot free or resize, and will return null
-    when it has used all memory in the buffer given to it.
-    
-    This kind of allocator is useful for temporary string building or
-    similar circumstances, where you know that the needed memory size
-    will not be exceeded, but you don't what to deal with potential
-    slowness of a general heap allocator. By using this allocator, you
-    can continue to use the same code that does allocations like normal,
-    but can get the speed increase of a simple allocation strategy.
-"""
 
 use core
 

--- a/core/alloc/gc.onyx
+++ b/core/alloc/gc.onyx
@@ -1,19 +1,17 @@
+/// "Garbage collection" is not somthing Onyx has. Even things
+/// like reference counted pointers is not something Onyx can
+/// do, because of Onyx's simpler semantics. That being said,
+/// with custom allocators and some careful design, GC is
+/// "achievable". This allocator wraps another allocator. With
+/// each allocation, a little extra space is allocated to build
+/// a linked list of all allocations made. This way, when the
+/// memory is done being used, everything can be freed automatically.
+///
+/// The `auto` macro makes this allocator very easy to use:
+///     core.alloc.gc.auto() {
+///         // Every allocation here will automatically be freed
+///     }
 package core.alloc.gc
-#package_doc """
-    "Garbage collection" is not somthing Onyx has. Even things
-    like reference counted pointers is not something Onyx can
-    do, because of Onyx's simpler semantics. That being said,
-    with custom allocators and some careful design, GC is
-    "achievable". This allocator wraps another allocator. With
-    each allocation, a little extra space is allocated to build
-    a linked list of all allocations made. This way, when the
-    memory is done being used, everything can be freed automatically.
-
-    The `auto` macro makes this allocator very easy to use:
-        core.alloc.gc.auto() {
-            // Every allocation here will automatically be freed
-        }
-"""
 
 
 use runtime
@@ -157,10 +155,8 @@ GC_Manually_Free_Magic_Number :: 0xface1337
     return cast([&] GCLink, newptr) + 1;
 }
 
-#doc """
-    Removes an allocation from the garbage collectors tracking list,
-    so it will not be freed automatically.
-"""
+/// Removes an allocation from the garbage collectors tracking list,
+/// so it will not be freed automatically.
 untrack :: (ptr: rawptr) -> bool {
     link: &GCLink = (cast([&] GCLink) ptr) - 1;
 

--- a/core/alloc/logging.onyx
+++ b/core/alloc/logging.onyx
@@ -1,9 +1,7 @@
+/// This allocator simply wraps another allocator and
+/// prints every allocation/deallocation made by that 
+/// allocator.
 package core.alloc.log
-#package_doc """
-    This allocator simply wraps another allocator and
-    prints every allocation/deallocation made by that 
-    allocator.
-"""
 
 
 use core

--- a/core/alloc/memdebug.onyx
+++ b/core/alloc/memdebug.onyx
@@ -1,15 +1,13 @@
+/// The memory debugger allocator wraps an existing allocator (normally the heap allocator),
+/// and reports on a TCP socket all of the allocation operations done to the underlying
+/// allocator. This listener on this socket can use this information to show useful information
+/// about the memory usage in the program.
+///
+/// This is best used when it starts at the very beginning of the program.
+/// The easiest way to use this is to define MEMDEBUG in runtime.vars,
+/// or pass -DMEMDEBUG on the command line. 
 package core.alloc.memdebug
 #allow_stale_code
-#package_doc """
-    The memory debugger allocator wraps an existing allocator (normally the heap allocator),
-    and reports on a TCP socket all of the allocation operations done to the underlying
-    allocator. This listener on this socket can use this information to show useful information
-    about the memory usage in the program.
-
-    This is best used when it starts at the very beginning of the program.
-    The easiest way to use this is to define MEMDEBUG in runtime.vars,
-    or pass -DMEMDEBUG on the command line. 
-"""
 
 use core {Result}
 use core.alloc

--- a/core/alloc/pool.onyx
+++ b/core/alloc/pool.onyx
@@ -1,16 +1,14 @@
+/// A pool allocator is an O(1) allocator that is capable of allocating and freeing.
+/// It is able to do both in constant time because it maintains a linked list of all
+/// the free elements in the pool. When an element is requested the first element of
+/// linked list is returned and the list is updated. When an element is freed, it
+/// becomes the first element. The catch with this strategy however, is that all of
+/// the allocations must be of the same size. This would not be an allocator to use
+/// when dealing with heterogenous data, but when doing homogenous data, such as
+/// game entities, this allocator is great. It allows you to allocate and free as
+/// many times as you want, without worrying about fragmentation or slow allocators.
+/// Just make sure you don't allocate more than the pool can provide.
 package core.alloc.pool
-#package_doc """
-    A pool allocator is an O(1) allocator that is capable of allocating and freeing.
-    It is able to do both in constant time because it maintains a linked list of all
-    the free elements in the pool. When an element is requested the first element of
-    linked list is returned and the list is updated. When an element is freed, it
-    becomes the first element. The catch with this strategy however, is that all of
-    the allocations must be of the same size. This would not be an allocator to use
-    when dealing with heterogenous data, but when doing homogenous data, such as
-    game entities, this allocator is great. It allows you to allocate and free as
-    many times as you want, without worrying about fragmentation or slow allocators.
-    Just make sure you don't allocate more than the pool can provide.
-"""
 
 use core
 

--- a/core/alloc/ring.onyx
+++ b/core/alloc/ring.onyx
@@ -1,15 +1,13 @@
+/// This allocator is great for temporary memory, such as returning
+/// a pointer from a function, or storing a formatted string. The
+/// memory allocated using this allocator does not need to be freed.
+/// The idea is that as you keep allocating you will "wrap around"
+/// and start writing over memory that was allocated before. For this
+/// reason, it is not safe to use this for any kind of permanent
+/// allocation. Also, be wary that you provide this allocator with
+/// a buffer big enough to store as much data as you are going to need
+/// at any given time. 
 package core.alloc.ring
-#package_doc """
-    This allocator is great for temporary memory, such as returning
-    a pointer from a function, or storing a formatted string. The
-    memory allocated using this allocator does not need to be freed.
-    The idea is that as you keep allocating you will "wrap around"
-    and start writing over memory that was allocated before. For this
-    reason, it is not safe to use this for any kind of permanent
-    allocation. Also, be wary that you provide this allocator with
-    a buffer big enough to store as much data as you are going to need
-    at any given time. 
-"""
 
 use core
 

--- a/core/builtin.onyx
+++ b/core/builtin.onyx
@@ -35,30 +35,27 @@ dyn_str :: #type [..] u8;
 
 
 
-//
-// This is the type of a range literal (i.e. 1 .. 5).
-// This is a special type that the compiler knows how to iterator through.
-// So, one can simply write:
-//
-//      for x in 1 .. 5 { ... }
-//
-// Although not controllable from the literal syntax, there is a `step`
-// member that allows you control how many numbers to advance each iteration.
-// For example, range.{ 0, 100, 2 } would iterate over the even numbers, and
-// range.{ 100, 0, -1 } would count backwards from 100 to 0 (and including 0).
+/// This is the type of a range literal (i.e. 1 .. 5).
+/// This is a special type that the compiler knows how to iterator through.
+/// So, one can simply write:
+///
+///      for x in 1 .. 5 { ... }
+///
+/// Although not controllable from the literal syntax, there is a `step`
+/// member that allows you control how many numbers to advance each iteration.
+/// For example, range.{ 0, 100, 2 } would iterate over the even numbers, and
+/// range.{ 100, 0, -1 } would count backwards from 100 to 0 (and including 0).
 range :: struct {
     low  : i32;
     high : i32;
     step : i32 = 1;
 }
 
-//
-// To have parity between range32 and range64
+/// To have parity between range32 and range64
 range32 :: range
 
 
-//
-// This is the same as the `range` type, except with 64-bit integers.
+/// This is the same as the `range` type, except with 64-bit integers.
 range64 :: struct {
     low  : i64;
     high : i64;
@@ -73,35 +70,33 @@ range64 :: struct {
 // casts to all other pointer types.
 null :: cast(rawptr) 0
 
-#doc """
-    `null_proc` is a special function that breaks the normal rules of type
-    checking. `null_proc`, or any procedure marked with `#null`, is assignable
-    to any function type, regardless of if the types match. For example,
-
-        f: (i32) -> i32 = null_proc;
-
-    Even though `null_proc` is a `() -> void` function, it bypasses that check
-    and gets assigned to `f`. If f is called, there will be a runtime exception.
-    This is by design.
-"""
+/// `null_proc` is a special function that breaks the normal rules of type
+/// checking. `null_proc`, or any procedure marked with `#null`, is assignable
+/// to any function type, regardless of if the types match. For example,
+///
+///     f: (i32) -> i32 = null_proc;
+///
+/// Even though `null_proc` is a `() -> void` function, it bypasses that check
+/// and gets assigned to `f`. If f is called, there will be a runtime exception.
+/// This is by design.
 null_proc :: () -> void #null ---
 
-//
-// I find myself wanting to return a completely nullified string like the
-// one below that I decided to added a builtin binding for it. This might
-// go away at some point and would just need to be defined in every file.
+///
+/// I find myself wanting to return a completely nullified string like the
+/// one below that I decided to added a builtin binding for it. This might
+/// go away at some point and would just need to be defined in every file.
 null_str  :: str.{ null, 0 }
 
 
 
-//
-// The 'context' is used to store thread-local configuration for things like
-// allocators, loggers, exception handles, and other things. It is thread
-// local so every threads gets its own copy.
+///
+/// The 'context' is used to store thread-local configuration for things like
+/// allocators, loggers, exception handles, and other things. It is thread
+/// local so every threads gets its own copy.
 #thread_local context : OnyxContext;
 
-//
-// This is the type of the 'context' global variable.
+///
+/// This is the type of the 'context' global variable.
 OnyxContext :: struct {
     // The allocator used by default by the standard library. It is by
     // default the global heap allocator.
@@ -154,9 +149,9 @@ OnyxContext.get_user_data :: macro (c: &OnyxContext, $T: type_expr) -> &T {
 
 // CLEANUP: Does assert() need to be in the builtin file?
 // It uses context.assert_handler, but does it needt to be here?
-//
-// Checks if the condition is true. If not, invoke the context's
-// assert handler.
+
+/// Checks if the condition is true. If not, invoke the context's
+/// assert handler.
 assert :: (cond: bool, msg: str, site := #callsite) {
     if !cond {
         context.assert_handler(msg, site);
@@ -262,14 +257,12 @@ raw_alloc :: (use a: Allocator, size: u32, alignment := Default_Allocation_Align
     return func(data, AllocationAction.Alloc, size, alignment, null);
 }
 
-//
-// Helper procedure to resize an allocation from an allocator.
+/// Helper procedure to resize an allocation from an allocator.
 raw_resize :: (use a: Allocator, ptr: rawptr, size: u32, alignment := Default_Allocation_Alignment) -> rawptr {
     return func(data, AllocationAction.Resize, size, alignment, ptr);
 }
 
-//
-// Helper procedure to free an allocation from an allocator.
+/// Helper procedure to free an allocation from an allocator.
 raw_free :: (use a: Allocator, ptr: rawptr) {
     func(data, AllocationAction.Free, 0, 0, ptr);
 }
@@ -284,10 +277,11 @@ Allocator.move :: macro (use a: Allocator, v: $V) -> &V {
     return out;
 }
 
-//
-// Helper function to allocate/free using allocator in the context structure.
+/// Helper function to allocate using the allocator in the context structure.
 calloc  :: (size: u32)              => raw_alloc(context.allocator, size);
+/// Helper function to resize using the allocator in the context structure.
 cresize :: (ptr: rawptr, size: u32) => raw_resize(context.allocator, ptr, size);
+/// Helper function to free using the allocator in the context structure.
 cfree   :: (ptr: rawptr)            => raw_free(context.allocator, ptr);
 
 
@@ -363,24 +357,24 @@ cfree   :: (ptr: rawptr)            => raw_free(context.allocator, ptr);
         return make(T, n, allocator=context.temp_allocator);
     }
 
-    //
-    // This is a rather unique way of using the type matching system
-    // to select an overload. What is desired here is that when you say:
-    //
-    //    make(Foo)
-    //
-    // You match the overload for make that is designed for making a Foo.
-    // However, you cannot use the type matching system to match by value.
-    // In order to get around this, `make` will pass a null pointer to this
-    // match procedure, that is casted to be a *pointer* to the desired type.
-    // Therefore, if you want to add your own make overload, you have to add
-    // a match to `__make_overload` that takes a *pointer* to the desired
-    // type as the first argument, and then an allocator as the second.
-    // Optionally, you can take a parameter between them that is an integer,
-    // useful when constructing things like arrays.
-    //
-    // See core/container/array.onyx for an example.
-    //
+    ///
+    /// This is a rather unique way of using the type matching system
+    /// to select an overload. What is desired here is that when you say:
+    ///
+    ///    make(Foo)
+    ///
+    /// You match the overload for make that is designed for making a Foo.
+    /// However, you cannot use the type matching system to match by value.
+    /// In order to get around this, `make` will pass a null pointer to this
+    /// match procedure, that is casted to be a *pointer* to the desired type.
+    /// Therefore, if you want to add your own make overload, you have to add
+    /// a match to `__make_overload` that takes a *pointer* to the desired
+    /// type as the first argument, and then an allocator as the second.
+    /// Optionally, you can take a parameter between them that is an integer,
+    /// useful when constructing things like arrays.
+    ///
+    /// See core/container/array.onyx for an example.
+    ///
     __make_overload :: #match {}
 
     delete :: #match {}
@@ -401,29 +395,28 @@ cfree   :: (ptr: rawptr)            => raw_free(context.allocator, ptr);
 }
 
 
-#doc """
-   Represents a generic "iterator" or "generator" of a specific
-   type. Can be used in a for-loop natively.
 
-   `data` is used for contextual information and is passed to
-   the `next`, `close`, and `remove` procedures.
-
-   `next` is used to extract the next value out of the iterator.
-   It returns the next value, and a continuation flag. If the
-   flag is false, the value should be ignored and iteration should
-   stop.
-
-   `close` should called when the iterator has ended. This is
-   done automatically in for-loops, and in the `core.iter` library.
-   In for-loops, `close` is called no matter which way the for-loop
-   exits (`break`, `return`, etc). Using this rule, iterator can
-   be used to create "resources" that automatically close when you
-   are done with them.
-
-   `remove` is used to tell the iterator to remove the last value
-   returned from some underlying data store. Invoked automatically
-   using the `#remove` directive in a for-loop.
-"""
+/// Represents a generic "iterator" or "generator" of a specific
+/// type. Can be used in a for-loop natively.
+///
+/// `data` is used for contextual information and is passed to
+/// the `next`, `close`, and `remove` procedures.
+///
+/// `next` is used to extract the next value out of the iterator.
+/// It returns the next value, and a continuation flag. If the
+/// flag is false, the value should be ignored and iteration should
+/// stop.
+///
+/// `close` should called when the iterator has ended. This is
+/// done automatically in for-loops, and in the `core.iter` library.
+/// In for-loops, `close` is called no matter which way the for-loop
+/// exits (`break`, `return`, etc). Using this rule, iterator can
+/// be used to create "resources" that automatically close when you
+/// are done with them.
+///
+/// `remove` is used to tell the iterator to remove the last value
+/// returned from some underlying data store. Invoked automatically
+/// using the `#remove` directive in a for-loop.
 Iterator :: struct (Iter_Type: type_expr) {
     data:   rawptr;
     next:   (data: rawptr) -> (Iter_Type, bool);
@@ -432,37 +425,31 @@ Iterator :: struct (Iter_Type: type_expr) {
 }
 
 
-#doc """
-    Optional represents the possibility of a value being empty, without
-    resorting to pointers and null-pointers. Most of the functionality
-    for Optional is defined in core/containers/optional.onyx. This
-    definition exists here because the compiler use it as the template
-    for types like '? i32'. In other words, '? i32' is equivalent to
-    'Optional(i32)'.
-"""
+/// Optional represents the possibility of a value being empty, without
+/// resorting to pointers and null-pointers. Most of the functionality
+/// for Optional is defined in core/containers/optional.onyx. This
+/// definition exists here because the compiler use it as the template
+/// for types like '? i32'. In other words, '? i32' is equivalent to
+/// 'Optional(i32)'.
 Optional :: union (Value_Type: type_expr) {
     None: void;
     Some: Value_Type;
 }
 
 
-#doc """
-    This structure represents the slice types, `[] T`.
-    While slices are a special type in Onyx, and therefore need extra
-    compiler support, this structure exists to allow for placing
-    methods onto slices. See `core/container/slice.onyx` for examples.
-"""
+/// This structure represents the slice types, `[] T`.
+/// While slices are a special type in Onyx, and therefore need extra
+/// compiler support, this structure exists to allow for placing
+/// methods onto slices. See `core/container/slice.onyx` for examples.
 Slice :: struct (T: type_expr) {
     data: [&] T;
     count: i32;
 }
 
 
-#doc """
-    This structure represents the dynamic array types, `[..] T`.
-    This structure exists to allow for placing methods onto dynamic arrays.
-    See `core/container/array.onyx` for examples.
-"""
+/// This structure represents the dynamic array types, `[..] T`.
+/// This structure exists to allow for placing methods onto dynamic arrays.
+/// See `core/container/array.onyx` for examples.
 Array :: struct (T: type_expr) {
     data: [&] T;
     count: i32;
@@ -471,12 +458,10 @@ Array :: struct (T: type_expr) {
 }
 
 
-#doc """
-    This structure represents the result of a '#callsite' expression. Currently, #callsite
-    is only valid (and parsed) as a default value for a procedure parameter. It allows
-    the function to get the address of the calling site, which can be used for error
-    printing, unique hashes, and much more.
-"""
+/// This structure represents the result of a '#callsite' expression. Currently, #callsite
+/// is only valid (and parsed) as a default value for a procedure parameter. It allows
+/// the function to get the address of the calling site, which can be used for error
+/// printing, unique hashes, and much more.
 CallSite :: struct {
     file   : str;
     line   : u32;
@@ -484,66 +469,51 @@ CallSite :: struct {
 }
 
 
-#doc """
-    This structure is used to represent any value in the language.
-    It contains a pointer to the data, and the type of the value.
-    Using the `core.misc` library, you can easily manipulate `any`s
-    and build runtime polymorphism.
-"""
+/// This structure is used to represent any value in the language.
+/// It contains a pointer to the data, and the type of the value.
+/// Using the `core.misc` library, you can easily manipulate `any`s
+/// and build runtime polymorphism.
 any :: struct {
     data: rawptr;
     type: type_expr;
 }
 
-#doc """
-    Represents a code block that can be passed around at compile-time.
-    This is commonly used with macros or polymorphic procedures to create
-    very power extensions to the syntax.
-"""
+/// Represents a code block that can be passed around at compile-time.
+/// This is commonly used with macros or polymorphic procedures to create
+/// very power extensions to the syntax.
 Code :: struct {_:i32;}
 
 
 
-#doc """
-    This procedure is a special compiler generated procedure that initializes all the data segments
-    in the program. It should only be called once, by the main thread, at the start of execution. It
-    is undefined behaviour if it is called more than once.
-"""
+/// This procedure is a special compiler generated procedure that initializes all the data segments
+/// in the program. It should only be called once, by the main thread, at the start of execution. It
+/// is undefined behaviour if it is called more than once.
 __initialize_data_segments :: () -> void ---
 
-#doc """
-    This is a special compiler generated procedure that calls all procedures specified with `#init`
-    in the specified order. It should theoretically only be called once on the main thread.
-"""
+/// This is a special compiler generated procedure that calls all procedures specified with `#init`
+/// in the specified order. It should theoretically only be called once on the main thread.
 __run_init_procedures :: () -> void ---
 
-#doc """
-    This overloaded procedure allows you to define an implicit rule for how to convert any value
-    into a boolean. A default is provided for ALL pointer types and array types, but this can
-    be used for structures or distinct types.
-"""
+/// This overloaded procedure allows you to define an implicit rule for how to convert any value
+/// into a boolean. A default is provided for ALL pointer types and array types, but this can
+/// be used for structures or distinct types.
 __implicit_bool_cast :: #match -> bool {}
 
-#doc """
-    Internal procedure to allocate space for the captures in a closure. This will be soon
-    changed to a configurable way, but for now it simply allocates out of the heap allocator.
-"""
+/// Internal procedure to allocate space for the captures in a closure. This will be soon
+/// changed to a configurable way, but for now it simply allocates out of the heap allocator.
 __closure_block_allocate :: (size: i32) -> rawptr {
     return context.closure_allocate(size);
 }
 
 
-#doc """
-"""
+///
 __dispose_used_local :: #match -> void {
     #order 10000 delete
 }
 
 
-#doc """
-    Defines all options for changing the memory layout, imports and exports,
-    and more of an Onyx binary.
-"""
+/// Defines all options for changing the memory layout, imports and exports,
+/// and more of an Onyx binary.
 Link_Options :: struct {
     // By default the memory layout of a binary is:
     //   reserved | static-data | stack | heap
@@ -602,20 +572,18 @@ Link_Options :: struct {
 }
 
 
-#doc """
-    Special type used to represent a package at runtime.
-    For example,
-
-        x: package_id = package main
-
-    Currently, there is not much you can do with this; it is
-    only used by the runtime.info library if you want to filter
-    tags based on which package they are coming from.
-"""
+/// Special type used to represent a package at runtime.
+/// For example,
+///
+///     x: package_id = package main
+///
+/// Currently, there is not much you can do with this; it is
+/// only used by the runtime.info library if you want to filter
+/// tags based on which package they are coming from.
 package_id :: #distinct u32
 
-//
-// Special value used to represents any package.
+///
+/// Special value used to represents any package.
 any_package :: cast(package_id) 0
 
 //
@@ -626,12 +594,11 @@ any_package :: cast(package_id) 0
 // DEPRECATED THINGS
 //
 
-//
-// This is the special type of a paramter that was declared to have the type '...'.
-// This is an old feature of the language now called  'untyped varargs'. It had
-// a similar construction to varargs in C/C++. Because it is incredibly unsafe
-// and not programmer friendly, this way of doing it has been deprecated in
-// favor of  using '..any', which provides type information along with the data.
+/// This is the special type of a paramter that was declared to have the type '...'.
+/// This is an old feature of the language now called  'untyped varargs'. It had
+/// a similar construction to varargs in C/C++. Because it is incredibly unsafe
+/// and not programmer friendly, this way of doing it has been deprecated in
+/// favor of  using '..any', which provides type information along with the data.
 vararg :: #type &struct {
     data:  rawptr;
     count: i32;

--- a/core/container/array.onyx
+++ b/core/container/array.onyx
@@ -15,15 +15,11 @@ use core
 //           Dynamic Arrays
 // ---------------------------------
 
-#doc """
-    Creates a new dynamic array.
-"""
+/// Creates a new dynamic array.
 Array.make :: #match #local {}
 
-#doc """
-    Creates a dynamic array of type `T` with an initial capacity of `capacity`,
-    from the `allocator`.
-"""
+/// Creates a dynamic array of type `T` with an initial capacity of `capacity`,
+/// from the `allocator`.
 #overload
 Array.make :: ($T: type_expr, capacity := 4, allocator := context.allocator) -> [..] T {
     arr : [..] T;
@@ -31,9 +27,7 @@ Array.make :: ($T: type_expr, capacity := 4, allocator := context.allocator) -> 
     return arr;
 }
 
-#doc """
-    Creates a new dynamic array as a *copy* of the provided array.
-"""
+/// Creates a new dynamic array as a *copy* of the provided array.
 #overload
 Array.make :: (base: [] $T, allocator := context.allocator) -> [..] T {
     arr: [..] T;
@@ -52,7 +46,7 @@ __make_overload :: macro (_: &[..] $T, capacity: u32, allocator := context.alloc
     return Array.make(T, capacity, allocator);
 }
 
-#doc "Initializes a dynamic array."
+/// Initializes a dynamic array.
 Array.init :: (arr: &[..] $T, capacity := 4, allocator := context.allocator) {
     arr.count = 0;
     arr.capacity = capacity;
@@ -60,7 +54,7 @@ Array.init :: (arr: &[..] $T, capacity := 4, allocator := context.allocator) {
     arr.data = raw_alloc(allocator, sizeof T * arr.capacity);
 }
 
-#doc "Frees a dynamic array."
+/// Frees a dynamic array.
 Array.free :: (arr: &[..] $T) {
     arr.count = 0;
     arr.capacity = 0;
@@ -91,13 +85,11 @@ Array.copy :: #match #locked {
     }
 }
 
-#doc """
-    Copies a sub-array of a dynamic-array.
-
-        arr := array.make(.[ 2, 3, 5, 7, 11 ]);
-        sub := array.copy_range(&arr, 2 .. 5);
-        println(sub); // 5, 7, 11
-"""
+/// Copies a sub-array of a dynamic-array.
+///
+///     arr := array.make(.[ 2, 3, 5, 7, 11 ]);
+///     sub := array.copy_range(&arr, 2 .. 5);
+///     println(sub); // 5, 7, 11
 Array.copy_range :: (arr: &[..] $T, r: range, allocator := context.allocator) -> [..] T {
     new_arr : [..] T;
     Array.init(&new_arr, r.high - r.low, allocator);
@@ -107,20 +99,16 @@ Array.copy_range :: (arr: &[..] $T, r: range, allocator := context.allocator) ->
     return new_arr;
 }
 
-#doc """
-    Clears a dynamic array.
-
-    Note: This does not clear or free the memory for the dynamic array.
-"""
+/// Clears a dynamic array.
+///
+/// Note: This does not clear or free the memory for the dynamic array.
 Array.clear :: (arr: &[..] $T) {
     arr.count = 0;
 }
 
-#doc """
-    Resizes a dynamic array if it does not have enough capacity.
-
-    If this procedure returns `true`, `arr.capacity` will be greater than or equal to `capacity`.
-"""
+/// Resizes a dynamic array if it does not have enough capacity.
+///
+/// If this procedure returns `true`, `arr.capacity` will be greater than or equal to `capacity`.
 Array.ensure_capacity :: (arr: &[..] $T, capacity: u32) -> bool {
     if arr.capacity >= capacity do return true;
     if arr.data == null do Array.init(arr);
@@ -132,18 +120,14 @@ Array.ensure_capacity :: (arr: &[..] $T, capacity: u32) -> bool {
     return true;
 }
 
-#doc """
-    Appends a zeroed-element to the end of the array, and returns a pointer to it.
-"""
+/// Appends a zeroed-element to the end of the array, and returns a pointer to it.
 Array.alloc_one :: (arr: &[..] $T) -> &T {
     if !Array.ensure_capacity(arr, arr.count + 1) do return null;
     arr.count += 1;
     return &arr.data[arr.count - 1];
 }
 
-#doc """
-    Appends `x` to the end of the array.
-"""
+/// Appends `x` to the end of the array.
 Array.push :: (arr: &[..] $T, x: T) -> bool {
     if !Array.ensure_capacity(arr, arr.count + 1) do return false;
     arr.data[arr.count] = x;
@@ -157,11 +141,9 @@ Array.push :: (arr: &[..] $T, x: T) -> bool {
 }
 
 
-#doc """
-    Inserts element(s) into the middle of the array at `idx`.
-
-    If `idx >= arr.count`, nothing happens.
-"""
+/// Inserts element(s) into the middle of the array at `idx`.
+///
+/// If `idx >= arr.count`, nothing happens.
 Array.insert :: #match #local {}
 
 #overload
@@ -196,9 +178,7 @@ Array.insert :: (arr: &[..] $T, idx: u32, new_arr: [] T) -> bool {
     return true;
 }
 
-#doc """
-    Inserts a zeroed-element at `idx`.
-"""
+/// Inserts a zeroed-element at `idx`.
 Array.insert_empty :: (arr: &[..] $T, idx: u32) -> bool {
     if idx > arr.count do return false;
     if !Array.ensure_capacity(arr, arr.count + 1) do return false;
@@ -212,11 +192,9 @@ Array.insert_empty :: (arr: &[..] $T, idx: u32) -> bool {
     return true;
 }
 
-#doc """
-    Removes all instances of `elem` from the array.
-
-    Uses `==` to test for equality.
-"""
+/// Removes all instances of `elem` from the array.
+///
+/// Uses `==` to test for equality.
 Array.remove :: (arr: &[..] $T, elem: T) {
     move := 0;
 
@@ -233,11 +211,9 @@ Array.remove :: (arr: &[..] $T, elem: T) {
     arr.count -= move;
 }
 
-#doc """
-    Removes the element at index `idx` from the array and returns it.
-
-    Maintains order of the array.
-"""
+/// Removes the element at index `idx` from the array and returns it.
+///
+/// Maintains order of the array.
 Array.delete :: (arr: &[..] $T, idx: u32) -> T {
     if idx >= arr.count do return .{};
 
@@ -250,11 +226,9 @@ Array.delete :: (arr: &[..] $T, idx: u32) -> T {
     return to_return;
 }
 
-#doc """
-    Removes the element at index `idx` from the array and returns it.
-
-    Order is not guaranteed to be preserved.
-"""
+/// Removes the element at index `idx` from the array and returns it.
+///
+/// Order is not guaranteed to be preserved.
 Array.fast_delete :: (arr: &[..] $T, idx: u32) -> T {
     if idx >= arr.count do return .{};
 
@@ -265,11 +239,7 @@ Array.fast_delete :: (arr: &[..] $T, idx: u32) -> T {
     return to_return;
 }
 
-#doc """
-    Removes `n` elements from the end of the array.
-
-    `n` by default is 1.
-"""
+/// Removes `n` elements from the end of the array.
 Array.pop :: (arr: &[..] $T, n := 1) -> T {
     if arr.count == 0 do return .{};
 
@@ -279,9 +249,7 @@ Array.pop :: (arr: &[..] $T, n := 1) -> T {
 }
 
 
-#doc """
-    Appends elements from another array or iterator to the end of the array.
-"""
+/// Appends elements from another array or iterator to the end of the array.
 Array.concat :: #match #local {}
 
 #overload
@@ -299,15 +267,11 @@ Array.concat :: (arr: &[..] $T, other: Iterator(T)) {
     }
 }
 
-#doc """
-    Removes all elements for which the given predicate does not hold.
-
-    Use `it` to refer to the current element being tested.
-
-        arr := array.make(.[ 1, 2, 3, 4, 5 ]);
-        array.filter(&arr, [v](v % 2 == 0));
-        println(arr); // 2, 4
-"""
+/// Removes all elements for which the given predicate does not hold.
+///
+///     arr := array.make(.[ 1, 2, 3, 4, 5 ]);
+///     array.filter(&arr, [v](v % 2 == 0));
+///     println(arr); // 2, 4
 Array.filter :: macro (arr: &[..] $T, body: Code) {
     move := 0;
 
@@ -327,8 +291,8 @@ Array.filter :: macro (arr: &[..] $T, body: Code) {
 }
 
 
-// Useful structure when talking about dynamic arrays where you don't know of what
-// type they store. For example, when passing a dynamic array as an 'any' argument.
+/// Useful structure when talking about dynamic arrays where you don't know of what
+/// type they store. For example, when passing a dynamic array as an 'any' argument.
 Untyped_Array :: struct {
     data: rawptr;
     count: u32;

--- a/core/container/iter.onyx
+++ b/core/container/iter.onyx
@@ -39,42 +39,33 @@ Iterator.collect_map :: to_map;
 
 
 
-#doc """
-    The standard function to convert something to an Iterator.
-    For-loops currently do not use this function to determine
-    how to iterate over something unknown, but that could be
-    a feature down the line.
-"""
+/// The standard function to convert something to an Iterator.
+/// For-loops currently do not use this function to determine
+/// how to iterate over something unknown, but that could be
+/// a feature down the line.
 as_iter :: #match -> Iterator {}
 
-#doc """
-    Helper interface to test if something can be passed to
-    as_iter successfully.
-"""
+/// Helper interface to test if something can be passed to
+/// as_iter successfully.
 Iterable :: interface (T: type_expr) {
     t as T;
     { as_iter(t) } -> Iterator;
 }
 
-#doc "Helper function to get the next value out of an iterator."
+/// Helper function to get the next value out of an iterator.
 next :: (it: Iterator) -> (it.Iter_Type, bool) {
     return it.next(it.data);
 }
 
-#doc """
-    Helper function to get the next value out of an iterator, but translated to an optional.
-    Returns `None` if the iterator was empty, `Some(value)` otherwise.
-"""
+/// Helper function to get the next value out of an iterator, but translated to an optional.
+/// Returns `None` if the iterator was empty, `Some(value)` otherwise.
 next_opt :: (it: Iterator) -> ? it.Iter_Type {
     v, exists := it.next(it.data);
     if exists do return v;
     return .{};
 }
 
-#doc """
-    Helper function to close an iterator, if a close function
-    is defined.
-"""
+/// Helper function to close an iterator, if a close function is defined.
 close :: (it: Iterator) {
     if it.close != null_proc {
         it.close(it.data);
@@ -82,9 +73,7 @@ close :: (it: Iterator) {
 }
 
 
-#doc """
-    Helper function to create an iterator of a type that does not produce an values.
-"""
+/// Helper function to create an iterator of a type that does not produce an values.
 empty :: ($T: type_expr) -> Iterator(T) {
     return .{
         // CLEANUP: Fix the compiler bug that makes this not able to a closure.
@@ -95,13 +84,11 @@ empty :: ($T: type_expr) -> Iterator(T) {
 }
 
 
-#doc """
-    Helper function to create an infinite counting iterator.
-
-    Use `start` to configure the starting value.
-
-    Use `type` to configure the type used for the iterator.
-"""
+/// Helper function to create an infinite counting iterator.
+///
+/// Use `start` to configure the starting value.
+///
+/// Use `type` to configure the type used for the iterator.
 counter :: (start: type = 0, $type: type_expr = i32) -> Iterator(type) {
     return generator(
         &.{ i = start },
@@ -162,7 +149,7 @@ HasAsIter :: interface (T: type_expr) {
 // Most of these procedures come in two variants,
 // one that takes a context paramter, and one that does not.
 
-#doc "Only yields the values for which the predicate is true."
+/// Only yields the values for which the predicate is true.
 filter :: #match #local {}
 
 #overload
@@ -208,10 +195,8 @@ filter :: (it: Iterator($T), ctx: $Ctx, predicate: (T, Ctx) -> bool) =>
         fi => { close(fi.iterator); });
 
 
-#doc """
-    Transforms every value that comes out of an iterator
-    using the transform function.
-"""
+/// Transforms every value that comes out of an iterator
+/// using the transform function.
 map :: #match #local {}
 
 #overload
@@ -247,14 +232,12 @@ map :: (it: Iterator($T), ctx: $Ctx, transform: (T, Ctx) -> $R) =>
         mi => { close(mi.iterator); })
 
 
-#doc """
-    Transforms every value that comes out of an iterator
-    using the transform function into a new iterator, from
-    which subsequent values will be output.
-
-        iter.flat_map(iter.as_iter(1 .. 5), x => iter.as_iter(1 .. x+1))
-        // 1, 1, 2, 1, 2, 3, 1, 2, 3, 4
-"""
+/// Transforms every value that comes out of an iterator
+/// using the transform function into a new iterator, from
+/// which subsequent values will be output.
+///
+///     iter.flat_map(iter.as_iter(1 .. 5), x => iter.as_iter(1 .. x+1))
+///     // 1, 1, 2, 1, 2, 3, 1, 2, 3, 4
 flat_map :: #match #local {}
 
 #overload
@@ -316,7 +299,7 @@ flat_map :: (it: Iterator($T), ctx: $Ctx, transform: (T, Ctx) -> Iterator($R)) =
 
 
 
-#doc "Only yields the first `count` values, then closes."
+/// Only yields the first `count` values, then closes.
 take :: (it: Iterator($T), count: u32) -> Iterator(T) {
     return generator(
         &.{ iterator = it, remaining = count },
@@ -334,7 +317,7 @@ take :: (it: Iterator($T), count: u32) -> Iterator(T) {
 }
 
 
-#doc "Yields values while the predicate returns true."
+/// Yields values while the predicate returns true.
 take_while :: (it: Iterator($T), predicate: (T) -> bool) -> Iterator(T) {
     return generator(
         &.{ iterator = it, predicate = predicate },
@@ -350,7 +333,7 @@ take_while :: (it: Iterator($T), predicate: (T) -> bool) -> Iterator(T) {
 }
 
 
-#doc "Discards the first `count` values and yields all remaining values."
+/// Discards the first `count` values and yields all remaining values.
 skip :: (it: Iterator($T), count: u32) -> Iterator(T) {
     return generator(
         &.{ iterator = it, to_skip = count, skipped = false },
@@ -373,7 +356,7 @@ skip :: (it: Iterator($T), count: u32) -> Iterator(T) {
 }
 
 
-#doc "Discards values while the predicate is true, then yields all values."
+/// Discards values while the predicate is true, then yields all values.
 skip_while :: #match #local {}
 
 #overload
@@ -429,10 +412,8 @@ skip_while :: (it: Iterator($T), ctx: $Ctx, predicate: (T, Ctx) -> bool) -> Iter
 }
 
 
-#doc """
-    Combines two iterators into one by yielding a Pair of
-    the value from each of the iterators.
-"""
+/// Combines two iterators into one by yielding a Pair of
+/// the value from each of the iterators.
 zip :: (left_iterator: Iterator($T), right_iterator: Iterator($R)) -> Iterator(Pair(T, R)) {
     return generator(
         &.{ left_iter = left_iterator, right_iter = right_iterator },
@@ -448,14 +429,12 @@ zip :: (left_iterator: Iterator($T), right_iterator: Iterator($R)) -> Iterator(P
 }
 
 
-#doc """
-    Filters and maps at the same time.
-
-    If the provided function returns a None variant of Optional,
-    then the entry is discarded.
-
-    If the provided function returns `Some(x)`, then `x` is yielded.
-"""
+/// Filters and maps at the same time.
+///
+/// If the provided function returns a None variant of Optional,
+/// then the entry is discarded.
+///
+/// If the provided function returns `Some(x)`, then `x` is yielded.
 flatten :: (i: Iterator($T), f: (T) -> ? $R) -> Iterator(R) {
     return generator(
         &.{ i = i, f = f },
@@ -478,10 +457,8 @@ flatten :: (i: Iterator($T), f: (T) -> ? $R) -> Iterator(R) {
 }
 
 
-#doc """
-    Combines iterators by first yielding all values from
-    one, then yielding all values from the next, and so on.
-"""
+/// Combines iterators by first yielding all values from
+/// one, then yielding all values from the next, and so on.
 concat :: (iters: ..Iterator($T)) -> Iterator(T) {
     return generator(
         &.{
@@ -510,12 +487,12 @@ concat :: (iters: ..Iterator($T)) -> Iterator(T) {
         });
 }
 
-#doc "Yields the same value indefinitely. Useful with `iter.zip`."
+/// Yields the same value indefinitely. Useful with `iter.zip`.
 const :: (value: $T) -> Iterator(T) {
     return generator(&.{ v = value }, c => (c.v, true));
 }
 
-#doc "Yields a single value, then stops."
+/// Yields a single value, then stops.
 single :: (value: $T, dispose: (T) -> void = null_proc) -> Iterator(T) {
     return generator(&.{ v = value, yielded = false, dispose = dispose }, c => {
         if !c.yielded {
@@ -532,11 +509,9 @@ single :: (value: $T, dispose: (T) -> void = null_proc) -> Iterator(T) {
 }
 
 
-#doc """
-    Yields a value that contains:
-        1) the value from the iterator,
-        2) an incrementing integer.
-"""
+/// Yields a value that contains:
+///     1) the value from the iterator,
+///     2) an incrementing integer.
 enumerate :: #match #local {}
 
 #overload
@@ -568,33 +543,29 @@ enumerate :: (it: Iterator($T), start_index: i32 = 0) -> Iterator(Enumeration_Va
 
 
 
-#doc """
-    Extract the next value out of an iterator. Closes it when
-    the iterator is out of values, if no_close is false.
-"""
+/// Extract the next value out of an iterator. Closes it when
+/// the iterator is out of values, if no_close is false.
 take_one :: (it: Iterator($T), no_close := false) -> (T, bool) {
     ret, cont := next(it);
     if !cont && !no_close { close(it); }
     return ret, cont;
 }
 
-#doc """
-    Macro that allows you to extract elements from an iterator in a simple way:
-    
-    value: i32;
-    iterator: Iterator(i32) = ...;
-    
-    if [](value) << iterator {
-        ...iterater closed...
-    }
-"""
-#operator << macro (dest: Code, it: Iterator($T)) -> bool {
-    take_one :: take_one
-
-    cont: bool;
-    (#unquote dest), cont = take_one(it);
-    return !cont;
-}
+// Macro that allows you to extract elements from an iterator in a simple way:
+// 
+// value: i32;
+// iterator: Iterator(i32) = ...;
+// 
+// if [](value) << iterator {
+//     ...iterater closed...
+// }
+//#operator << macro (dest: Code, it: Iterator($T)) -> bool {
+//    take_one :: take_one
+//
+//    cont: bool;
+//    (#unquote dest), cont = take_one(it);
+//    return !cont;
+//}
 
 
 //
@@ -606,16 +577,14 @@ take_one :: (it: Iterator($T), no_close := false) -> (T, bool) {
 #overload
 as_iter :: from_array
 
-#doc """
-    `from_array` has two almost identical implementations,
-    but the details are important here. Normally, `from_array`
-    returns an iterator by value, unless the array is of
-    structures, then it returns an iterator by pointer.
-    This seems weird, but in practice it is closer to what
-    you want, as you don't want to have to copy every structure
-    out of the array. While for primitives, you don't want to
-    dereference it everywhere.
-"""
+/// `from_array` has two almost identical implementations,
+/// but the details are important here. Normally, `from_array`
+/// returns an iterator by value, unless the array is of
+/// structures, then it returns an iterator by pointer.
+/// This seems weird, but in practice it is closer to what
+/// you want, as you don't want to have to copy every structure
+/// out of the array. While for primitives, you don't want to
+/// dereference it everywhere.
 from_array :: #match #local {}
 
 #overload
@@ -661,10 +630,8 @@ from_array :: (arr: [] $T) => generator(
 );
 
 
-#doc """
-    Iterators created from pointers to dynamic arrays are
-    special, because they support the #remove directive.
-"""
+/// Iterators created from pointers to dynamic arrays are
+/// special, because they support the #remove directive.
 #local
 generic_dynamic_array_as_iter :: (x: &[..] $T, $access: Code, $return_type: type_expr) => {
     Context :: struct (T: type_expr) {
@@ -783,11 +750,9 @@ find :: (it: Iterator($T), predicate: (T) -> bool) -> ? T {
 }
 
 
-#doc """
-    Incremently calls `combine` on the yielded value and the
-    accumulated value, producing a new accumulated value. Returns
-    the final accumulated value.
-"""
+/// Incremently calls `combine` on the yielded value and the
+/// accumulated value, producing a new accumulated value. Returns
+/// the final accumulated value.
 fold :: #match #local {}
 
 #overload
@@ -805,11 +770,9 @@ fold :: (it: Iterator($T), initial_value: $R, combine: (T, R) -> R) -> R {
     return result;
 }
 
-#doc """
-    Incremently calls `combine` on the yielded value and the
-    accumulated value, producing a new accumulated value. Returns
-    the final accumulated value.
-"""
+/// Incremently calls `combine` on the yielded value and the
+/// accumulated value, producing a new accumulated value. Returns
+/// the final accumulated value.
 fold1 :: #match #local {}
 
 #overload
@@ -829,7 +792,7 @@ fold1 :: (it: Iterator($T), combine: (T, T) -> T) -> ? T {
 }
 
 
-#doc "Returns how many times the `cond` was true."
+/// Returns how many times the `cond` was true.
 count :: #match #local {}
 
 #overload
@@ -845,7 +808,7 @@ count :: (it: Iterator($T), cond: (T) -> bool) -> i32 {
 
 
 
-#doc "Returns if `cond` returned true for *any* yielded value."
+/// Returns if `cond` returned true for *any* yielded value.
 some :: #match #local {}
 
 #overload
@@ -859,7 +822,7 @@ some :: (it: Iterator($T), cond: (T) -> bool) -> bool {
 }
 
 
-#doc "Returns if `cond` returned true for *all* yielded values."
+/// Returns if `cond` returned true for *all* yielded values.
 every :: #match #local {}
 
 #overload
@@ -872,7 +835,7 @@ every :: (it: Iterator($T), cond: (T) -> bool) -> bool {
     return true;
 }
 
-#doc "Returns the sum of all yield values, using the `+` operator."
+/// Returns the sum of all yield values, using the `+` operator.
 sum :: #match #local {}
 
 #overload
@@ -891,10 +854,8 @@ sum :: (it: Iterator($T)) -> T {
 }
 
 
-#doc """
-    Places all yielded values into a dynamically allocated array,
-    using the allocator provided (context.allocator by default).
-"""
+/// Places all yielded values into a dynamically allocated array,
+/// using the allocator provided (context.allocator by default).
 to_array :: (it: Iterator($T), allocator := context.allocator) -> [..] T {
     arr := array.make(T, allocator=allocator);
     for v in it do array.push(&arr, v);
@@ -902,8 +863,8 @@ to_array :: (it: Iterator($T), allocator := context.allocator) -> [..] T {
     return arr;
 }
 
-#doc """
-"""
+/// Places all yielded values into a Map, with the `first` member
+/// being the key, and the `second` member being the value.
 to_map :: (it: Iterator(Pair($K, $V)), allocator := context.allocator) -> Map(K, V) {
     m := builtin.make(Map(K, V), allocator=allocator);
     for p in it {
@@ -912,27 +873,23 @@ to_map :: (it: Iterator(Pair($K, $V)), allocator := context.allocator) -> Map(K,
     return m;
 }
 
-#doc """
-    Collects elements into an array, or a map, depending on if the
-    iterator produces a Pair(K, V) or not.
-"""
+/// Collects elements into an array, or a map, depending on if the
+/// iterator produces a Pair(K, V) or not.
 collect :: #match {
     to_array
 }
 
 
-#doc """
-    Produces an iterator that first yields all values from the
-    first iterable, combined with the first yield value from the
-    second iterable. Then, steps the second iterable, and repeats.
-   
-    For example,
-   
-         iter.prod(1 .. 4, 1 .. 3)
-   
-    Would yield:
-         (1, 1), (2, 1), (3, 1), (1, 2), (2, 2), (3, 2)
-"""
+/// Produces an iterator that first yields all values from the
+/// first iterable, combined with the first yield value from the
+/// second iterable. Then, steps the second iterable, and repeats.
+///
+/// For example,
+///
+///      iter.prod(1 .. 4, 1 .. 3)
+///
+/// Would yield:
+///      (1, 1), (2, 1), (3, 1), (1, 2), (2, 2), (3, 2)
 prod :: #match #local {}
 
 #overload
@@ -972,15 +929,13 @@ prod :: (x: $I1/Iterable, y_iter: Iterator($Y)) => {
 }
 
 
-#doc """
-    Simple iterator comprehensions, in the same vein
-    as Pythons comprehension syntax.
-    
-    Python:
-        results = [it * 2 for it in [1, 2, 3, 4, 5]]
-    Onyx:
-        results := iter.comp(u32.[1, 2, 3, 4, 5], [it](it * 2));
-"""
+/// Simple iterator comprehensions, in the same vein
+/// as Pythons comprehension syntax.
+/// 
+/// Python:
+///     results = [it * 2 for it in [1, 2, 3, 4, 5]]
+/// Onyx:
+///     results := iter.comp(u32.[1, 2, 3, 4, 5], [it](it * 2));
 comp :: #match #local {}
 
 #overload
@@ -1009,14 +964,12 @@ comp :: macro (i: $I/Iterable, value: Code) =>
     #this_package.comp(#this_package.as_iter(i), value);
 
 
-#doc """
-    Using the polymorph solving system, you can write type
-    free versions of arbitrary iterators. This is used
-    heavily by many of the functions defined above.
-    
-    Maybe at some point an alternate allocator would be good
-    for this? For now, I think the temporary allocator is sufficient.
-"""
+/// Using the polymorph solving system, you can write type
+/// free versions of arbitrary iterators. This is used
+/// heavily by many of the functions defined above.
+/// 
+/// Maybe at some point an alternate allocator would be good
+/// for this? For now, I think the temporary allocator is sufficient.
 generator :: #match #local {}
 
 #overload
@@ -1103,14 +1056,12 @@ generator_no_copy :: (ctx: &$Ctx, gen: (&Ctx) -> ($T, bool), close: (&Ctx) -> vo
         return .{c, #solidify next {T=it.Iter_Type}, #solidify close {T=it.Iter_Type}};
     }
 
-    #doc """
-        Allows you to easily write a parallelized for-loop over an iterator.
-        For example,
-        
-            iter.parallel_for(1 .. 100, 4, &.{}) {
-                printf("Thread {} has {}!\n", context.thread_id, it);
-            }
-    """
+    /// Allows you to easily write a parallelized for-loop over an iterator.
+    /// For example,
+    /// 
+    ///     iter.parallel_for(1 .. 100, 4, &.{}) {
+    ///         printf("Thread {} has {}!\n", context.thread_id, it);
+    ///     }
     parallel_for :: #match #local {}
 
     #overload

--- a/core/container/map.onyx
+++ b/core/container/map.onyx
@@ -9,11 +9,9 @@ use core.conv
 use core {Optional}
 use core.intrinsics.onyx { __initialize }
 
-#doc """
-    Map is a generic hash-map implementation that uses chaining.
-    Values can be of any type. Keys must of a type that supports
-    the core.hash.hash, and the '==' operator.
-"""
+/// Map is a generic hash-map implementation that uses chaining.
+/// Values can be of any type. Keys must of a type that supports
+/// the core.hash.hash, and the '==' operator.
 @conv.Custom_Format.{ #solidify format_map {K=Key_Type, V=Value_Type} }
 Map :: struct (Key_Type: type_expr, Value_Type: type_expr) where ValidKey(Key_Type) {
     allocator : Allocator;
@@ -44,25 +42,21 @@ Map :: struct (Key_Type: type_expr, Value_Type: type_expr) where ValidKey(Key_Ty
 builtin.Map :: Map
 
 
-#doc """
-   Allows for creation of a Map using make().
-  
-       m := make(Map(str, i32));
-"""
+/// Allows for creation of a Map using make().
+///
+///     m := make(Map(str, i32));
 #overload
 __make_overload :: macro (x: &Map($K, $V), allocator := context.allocator) =>
     #this_package.Map.make(K, V, allocator);
 
-#doc """
-   Creates and initializes a new map using the types provided.
-"""
+/// Creates and initializes a new map using the types provided.
 Map.make :: macro ($Key: type_expr, $Value: type_expr, allocator := context.allocator) -> Map(Key, Value) {
     map : Map(Key, Value);
     #this_package.Map.init(&map, allocator);
     return map;
 }
 
-#doc "Initializes a map."
+/// Initializes a map.
 Map.init :: (map: &Map($K, $V), allocator := context.allocator) {
     __initialize(map);
 
@@ -74,21 +68,17 @@ Map.init :: (map: &Map($K, $V), allocator := context.allocator) {
     Array.init(&map.entries, allocator=allocator);
 }
 
-#doc "Allows for deletion of a Map using `delete(&map)`."
+// Allows for deletion of a Map using `delete(&map)`.
 #overload
 builtin.delete :: Map.free
 
-#doc """
-    Destroys a map and frees all memory.
-"""
+/// Destroys a map and frees all memory.
 Map.free :: (use map: &Map) {
     if hashes.data != null  do memory.free_slice(&hashes, allocator=allocator);
     if entries.data != null do Array.free(&entries);
 }
 
-#doc """
-    Shallow copies a map using the allocator provided if one is provided, or the allocator on the old map otherwise.
-"""
+/// Shallow copies a map using the allocator provided if one is provided, or the allocator on the old map otherwise.
 Map.copy :: (oldMap: &Map, allocator: ? Allocator = .None) -> Map(oldMap.Key_Type, oldMap.Value_Type) {
     newMap: typeof *oldMap;
     newMap.allocator = allocator ?? oldMap.allocator;
@@ -98,10 +88,8 @@ Map.copy :: (oldMap: &Map, allocator: ? Allocator = .None) -> Map(oldMap.Key_Typ
     return newMap;
 }
 
-#doc """
-    Sets the value at the specified key, or creates a new entry
-    if the key was not already present.
-"""
+/// Sets the value at the specified key, or creates a new entry
+/// if the key was not already present.
 Map.put :: (use map: &Map, key: map.Key_Type, value: map.Value_Type) {
     lr := lookup(map, key);
 
@@ -116,21 +104,14 @@ Map.put :: (use map: &Map, key: map.Key_Type, value: map.Value_Type) {
     if full(map) do grow(map);
 }
 
-#doc """
-    Returns true if the map contains the key.
-"""
+/// Returns true if the map contains the key.
 Map.has :: (use map: &Map, key: map.Key_Type) -> bool {
     lr := lookup(map, key);
     return lr.entry_index >= 0;
 }
 
-#doc """
-    Returns the value at the specified key, or map.default_value if
-    the key is not present.
-
-    This is subject to change with the addition of Optional to the
-    standard library.
-"""
+/// Returns the value at the specified key, or `.None` if the value
+/// is not present
 Map.get :: (use map: &Map, key: map.Key_Type) -> ? map.Value_Type {
     lr := lookup(map, key);
     if lr.entry_index >= 0 do return entries[lr.entry_index].value;
@@ -138,10 +119,8 @@ Map.get :: (use map: &Map, key: map.Key_Type) -> ? map.Value_Type {
     return .{};
 }
 
-#doc """
-    Returns a pointer to the value at the specified key, or null if
-    the key is not present.
-"""
+/// Returns a pointer to the value at the specified key, or null if
+/// the key is not present.
 Map.get_ptr :: (use map: &Map, key: map.Key_Type) -> &map.Value_Type {
     lr := lookup(map, key);
     if lr.entry_index >= 0 do return &entries[lr.entry_index].value;
@@ -149,11 +128,9 @@ Map.get_ptr :: (use map: &Map, key: map.Key_Type) -> &map.Value_Type {
     return null;
 }
 
-#doc """
-    Returns a pointer to the value at the specified key. If the key
-    is not in the map, a new value is created and inserted, then the
-    pointer to that value is returned.
-"""
+/// Returns a pointer to the value at the specified key. If the key
+/// is not in the map, a new value is created and inserted, then the
+/// pointer to that value is returned.
 Map.get_ptr_or_create :: (use map: &Map, key: map.Key_Type) -> &map.Value_Type {
     lr := lookup(map, key);
     if lr.entry_index < 0 {
@@ -164,13 +141,11 @@ Map.get_ptr_or_create :: (use map: &Map, key: map.Key_Type) -> &map.Value_Type {
     return &entries[lr.entry_index].value;
 }
 
-#doc """
-    **DEPRECATED** - Use `map.get` instead.
-
-    Returns an Optional of the value at the specified key. The Optional
-    has a value if the key is present, otherwise the optional does not
-    have a value.
-"""
+/// **DEPRECATED** - Use `map.get` instead.
+///
+/// Returns an Optional of the value at the specified key. The Optional
+/// has a value if the key is present, otherwise the optional does not
+/// have a value.
 Map.get_opt :: (use map: &Map, key: map.Key_Type) -> ?map.Value_Type {
     lr := lookup(map, key);
     if lr.entry_index >= 0 do return Optional.make(entries[lr.entry_index].value);
@@ -178,7 +153,7 @@ Map.get_opt :: (use map: &Map, key: map.Key_Type) -> ?map.Value_Type {
     return .{};
 }
 
-#doc "Removes an entry from the map."
+/// Removes an entry from the map.
 Map.delete :: (use map: &Map, key: map.Key_Type) {
     lr := lookup(map, key);
     if lr.entry_index < 0 do return;
@@ -198,18 +173,16 @@ Map.delete :: (use map: &Map, key: map.Key_Type) {
     else                       do hashes[last.hash_index] = lr.entry_index;
 }
 
-#doc """
-Helper macro that finds a value by the key, and if it exists,
-runs the code, providing an `it` variable that is a pointer
-to the value.
-
-    m: Map(str, i32);
-    m->update("test") {
-        *it += 10;
-    }
-or:
-    m->update("test", [v](*v += 10));
-"""  
+/// Helper macro that finds a value by the key, and if it exists,
+/// runs the code, providing an `it` variable that is a pointer
+/// to the value.
+/// 
+///     m: Map(str, i32);
+///     m->update("test") {
+///         *it += 10;
+///     }
+/// or:
+///     m->update("test", [v](*v += 10));
 Map.update :: macro (map: ^Map, key: map.Key_Type, body: Code) {
     lookup_ :: lookup
     lr := lookup_(map, key);
@@ -220,24 +193,20 @@ Map.update :: macro (map: ^Map, key: map.Key_Type, body: Code) {
     }
 }
 
-#doc """
-    Removes all entries from the hash map. Does NOT
-    modify memory, so be wary of dangling pointers!
-"""
+/// Removes all entries from the hash map. Does NOT
+/// modify memory, so be wary of dangling pointers!
 Map.clear :: (use map: &Map) {
     for i in 0 .. hashes.count do hashes.data[i] = -1;
     entries.count = 0;
 }
 
-#doc "Returns if the map does not contain any elements."
+/// Returns if the map does not contain any elements.
 Map.empty :: (use map: &Map) -> bool {
     return entries.count == 0;
 }
 
-#doc """
-    Helper procedure to nicely format a Map when printing.
-    Rarely ever called directly, instead used by conv.format_any.
-"""
+/// Helper procedure to nicely format a Map when printing.
+/// Rarely ever called directly, instead used by conv.format_any.
 Map.format_map :: (output: &conv.Format_Output, format: &conv.Format, x: &Map($K, $V)) {
     if format.pretty_printing {
         output->write("{\n");
@@ -256,14 +225,12 @@ Map.format_map :: (output: &conv.Format_Output, format: &conv.Format, x: &Map($K
     }
 }
 
-#doc """
-    Quickly create a Map with some entries.
-   
-        Map.literal(str, i32, .[
-            .{ "test", 123 },
-            .{ "foo",  456 },
-        ]);
-"""
+/// Quickly create a Map with some entries.
+///
+///     Map.literal(str, i32, .[
+///         .{ "test", 123 },
+///         .{ "foo",  456 },
+///     ]);
 Map.literal :: ($Key: type_expr, $Value: type_expr, values: [] MapLiteralValue(Key, Value)) => {
     m := core.map.make(Key, Value);
     for & values {
@@ -279,10 +246,8 @@ MapLiteralValue :: struct (K: type_expr, V: type_expr) {
     value: V;
 }
 
-#doc """
-    Produces an iterator that yields all values of the map,
-    in an unspecified order, as Map is unordered.
-"""
+/// Produces an iterator that yields all values of the map,
+/// in an unspecified order, as Map is unordered.
 Map.as_iter :: (m: &Map) =>
     core.iter.generator(
         &.{ m = m, i = 0 },

--- a/core/container/optional.onyx
+++ b/core/container/optional.onyx
@@ -13,54 +13,46 @@ use core
 // used by Map and Set in their `get_opt` function. In theory, it should
 // be used in many more places, instead of returning `.{}`.
 
-#doc """
-    Helper procedure for creating an Optional with a value.
-    Pass a type as the first argument to force the type, otherwise
-    the type will be inferred from the parameter type.
-"""
+/// Helper procedure for creating an Optional with a value.
+/// Pass a type as the first argument to force the type, otherwise
+/// the type will be inferred from the parameter type.
 Optional.make :: #match #locked {
     ((x: $T) => (?T).{ Some = x }),
     ($T: type_expr, x: T) => ((?T).{ Some = x })
 }
 
-#doc """
-    Create an empty Optional of a certain type. This procedure
-    is mostly useless, because you can use `.{}` in type inferred
-    places to avoid having to specify the type.
-"""
+/// Create an empty Optional of a certain type. This procedure
+/// is mostly useless, because you can use `.{}` in type inferred
+/// places to avoid having to specify the type.
 Optional.empty :: macro (T: type_expr) => (?T).{ None = .{} }; 
 
-#doc """
-    Converts a pointer to an optional by defining `null` to be `None`,
-    and a non-null pointer to be `Some`. This dereferences the valid
-    pointer to return the data stored at the pointer's address.
-"""
+/// Converts a pointer to an optional by defining `null` to be `None`,
+/// and a non-null pointer to be `Some`. This dereferences the valid
+/// pointer to return the data stored at the pointer's address.
 Optional.from_ptr :: macro (p: &$T) -> ?T {
     p_ := p;
     if p_ do return *p_;
     return .None;
 }
 
-#doc """
-    Extracts the value from the Optional, or uses a default if
-    no value is present.
-"""
+/// Extracts the value from the Optional, or uses a default if
+/// no value is present.
 Optional.value_or :: (o: ?$T, default: T) => switch o {
     case .Some as v => v;
     case #default => default;
 }
 
-#doc "Clears the value in the Optional, zeroing the memory of the value."
+/// Clears the value in the Optional, zeroing the memory of the value.
 Optional.reset :: (o: &?$T) {
     *o = .None;
 }
 
-#doc "Sets the value in the Optional."
+/// Sets the value in the Optional.
 Optional.set :: (o: &?$T, value: T) {
     *o = .{ Some = value };
 }
 
-#doc "Flattens nested optionals."
+/// Flattens nested optionals.
 // @Bug should be able to say ? ? $T here.
 Optional.flatten :: (o1: ? Optional($T)) -> ? T {
     switch o1 {
@@ -74,7 +66,7 @@ Optional.flatten :: (o1: ? Optional($T)) -> ? T {
     return .None;
 }
 
-#doc "Monadic chaining operation."
+/// Monadic chaining operation.
 Optional.and_then :: (o: ?$T, transform: (T) -> ?$R) -> ?R {
     return switch o {
         case .Some as v => transform(v);
@@ -82,7 +74,7 @@ Optional.and_then :: (o: ?$T, transform: (T) -> ?$R) -> ?R {
     };
 }
 
-#doc "Changes the value inside the optional, if present."
+/// Changes the value inside the optional, if present.
 Optional.transform :: (o: ?$T, transform: (T) -> $R) -> ?R {
     switch o {
         case .Some as v do return .{ Some = transform(v) };
@@ -90,10 +82,8 @@ Optional.transform :: (o: ?$T, transform: (T) -> $R) -> ?R {
     }
 }
 
-#doc """
-    Like `value_or`, but instead of providing a value, you
-    provide a function to generate a value.
-"""
+/// Like `value_or`, but instead of providing a value, you
+/// provide a function to generate a value.
 Optional.or_else :: (o: ?$T, generate: () -> ?T) -> ?T {
     return switch o {
         case .Some => o;
@@ -101,11 +91,9 @@ Optional.or_else :: (o: ?$T, generate: () -> ?T) -> ?T {
     };
 }
 
-#doc """
-    Returns the value inside the optional, if there is one.
-    If not, an assertion is thrown and the context's assert
-    handler must take care of it.
-"""
+/// Returns the value inside the optional, if there is one.
+/// If not, an assertion is thrown and the context's assert
+/// handler must take care of it.
 Optional.unwrap :: (o: ?$T) -> T {
     switch o {
         case .Some as v do return v;
@@ -116,11 +104,9 @@ Optional.unwrap :: (o: ?$T) -> T {
     }
 }
 
-#doc """
-    Returns a pointer to the value inside the optional, if there is one.
-    If not, an assertion is thrown and the context's assert handler must
-    take care of it.
-"""
+/// Returns a pointer to the value inside the optional, if there is one.
+/// If not, an assertion is thrown and the context's assert handler must
+/// take care of it.
 Optional.unwrap_ptr :: (o: & ?$T) -> &T {
     switch o {
         case .Some as &v do return v;
@@ -131,11 +117,9 @@ Optional.unwrap_ptr :: (o: & ?$T) -> &T {
     }
 }
 
-#doc """
-    Returns the value inside the optional, if there is one.
-    If not, an assertion is thrown and the context's assert
-    handler must take care of it.
-"""
+/// Returns the value inside the optional, if there is one.
+/// If not, an assertion is thrown and the context's assert
+/// handler must take care of it.
 Optional.expect :: (o: ?$T, message: str) -> T {
     switch o {
         case .Some as v do return v;
@@ -146,11 +130,9 @@ Optional.expect :: (o: ?$T, message: str) -> T {
     }
 }
 
-#doc """
-    Returns a pointer to the value inside the optional, if there is one.
-    If not, an assertion is thrown and the context's assert handler must
-    take care of it.
-"""
+/// Returns a pointer to the value inside the optional, if there is one.
+/// If not, an assertion is thrown and the context's assert handler must
+/// take care of it.
 Optional.expect_ptr :: (o: & ?$T, message: str) -> &T {
     switch o {
         case .Some as &v do return v;
@@ -198,33 +180,31 @@ Optional.with :: macro (o: ?$T, body: Code) {
     }
 }
 
-#doc """
-    Creates a scope that the `?` operator on an Optional type can
-    return to, instead of returning from the enclosing function.
-
-    Useful when chaining a bunch of operations that *could* fail,
-    while having a clean and easy escape hatch.
-
-        Optional.try() {
-            x := operation_1()?;
-            y := operation_2(x)?;
-            z := operation_3(x, y)?;
-            opreation_4(z);
-        }
-        println("Done");
-
-    In this example, if any of the operations fail, the execution
-    will cleanly go to `println` statement.
-
-    To know when something returned `None`, you can either use the second
-    parameter called `catch`, which is simply a block of code to be run.
-    Or you can use the return result from the function as so:
-    
-        // Sadly, cannot use the nicer syntax, `try() { ... }`
-        completed := Optional.try(#quote {
-            // ...
-        });
-"""
+/// Creates a scope that the `?` operator on an Optional type can
+/// return to, instead of returning from the enclosing function.
+///
+/// Useful when chaining a bunch of operations that *could* fail,
+/// while having a clean and easy escape hatch.
+///
+///     Optional.try() {
+///         x := operation_1()?;
+///         y := operation_2(x)?;
+///         z := operation_3(x, y)?;
+///         opreation_4(z);
+///     }
+///     println("Done");
+///
+/// In this example, if any of the operations fail, the execution
+/// will cleanly go to `println` statement.
+///
+/// To know when something returned `None`, you can either use the second
+/// parameter called `catch`, which is simply a block of code to be run.
+/// Or you can use the return result from the function as so:
+/// 
+///     // Sadly, cannot use the nicer syntax, `try() { ... }`
+///     completed := Optional.try(#quote {
+///         // ...
+///     });
 Optional.try :: macro (body: Code, catch: Code = []{}) -> bool {
     //
     // Using a 'do'-expression block to introduce a new

--- a/core/container/pair.onyx
+++ b/core/container/pair.onyx
@@ -1,14 +1,12 @@
 package core
 
 
-#doc """
-    A `Pair` represents a pair of values of heterogenous types.
-    This structure does not do much on its own; however, it
-    is useful because provides overloads for formatting, hashing
-    and equality. This means you can use a `Pair(T, R)` as a key
-    for a Map or Set out of the box, provided T and R are hashable
-    and equatable.
-"""
+/// A `Pair` represents a pair of values of heterogenous types.
+/// This structure does not do much on its own; however, it
+/// is useful because provides overloads for formatting, hashing
+/// and equality. This means you can use a `Pair(T, R)` as a key
+/// for a Map or Set out of the box, provided T and R are hashable
+/// and equatable.
 @conv.Custom_Format.{#solidify _format {First_Type=First_Type, Second_Type=Second_Type}}
 Pair :: struct (First_Type: type_expr, Second_Type: type_expr) {
     first: First_Type;

--- a/core/container/result.onyx
+++ b/core/container/result.onyx
@@ -13,18 +13,16 @@ use core.conv
 
 use core {Optional}
 
-#doc """
-    Result(T, E) is a structure that represents either an Ok value
-    of type T, or an Err value of type E. `status` contains either
-    .Ok, or .Err depending on which is currently held.
-"""
+/// Result(T, E) is a structure that represents either an Ok value
+/// of type T, or an Err value of type E. `status` contains either
+/// .Ok, or .Err depending on which is currently held.
 Result :: union (Ok_Type: type_expr, Err_Type: type_expr) {
     Err: Err_Type;
     Ok: Ok_Type;
 }
 
 
-#doc "Returns true if the result contains an Ok value."
+/// Returns true if the result contains an Ok value.
 Result.is_ok :: (r: #Self) -> bool {
     return switch r {
         case .Ok => true;
@@ -32,7 +30,7 @@ Result.is_ok :: (r: #Self) -> bool {
     };
 }
 
-#doc "Returns true if the result contains an Err value."
+/// Returns true if the result contains an Err value.
 Result.is_err :: (r: #Self) -> bool {
     return switch r {
         case .Err => true;
@@ -40,7 +38,7 @@ Result.is_err :: (r: #Self) -> bool {
     };
 }
 
-#doc "Returns an Optional of the Ok type."
+/// Returns an Optional of the Ok type.
 Result.ok :: (r: #Self) -> Optional(r.Ok_Type) {
     return switch r {
         case .Ok as v => Optional.make(v);
@@ -48,7 +46,7 @@ Result.ok :: (r: #Self) -> Optional(r.Ok_Type) {
     };
 }
 
-#doc "Returns an Optional of the Err type."
+/// Returns an Optional of the Err type.
 Result.err :: (r: #Self) -> Optional(r.Err_Type) {
     return switch r {
         case .Err as v => Optional.make(v);
@@ -56,10 +54,8 @@ Result.err :: (r: #Self) -> Optional(r.Err_Type) {
     };
 }
 
-#doc """
-    Forcefully extracts the Ok value out of the Result. If the
-    result contains an Err, an assertion is thrown.
-"""
+/// Forcefully extracts the Ok value out of the Result. If the
+/// result contains an Err, an assertion is thrown.
 Result.unwrap :: (r: #Self) -> r.Ok_Type {
     switch r {
         case .Ok as v do return v;
@@ -71,10 +67,8 @@ Result.unwrap :: (r: #Self) -> r.Ok_Type {
     }
 }
 
-#doc """
-    Tries to extract the Ok value out of the Result. If the
-    result contains an Err, the empty .{} value is returned.
-"""
+/// Tries to extract the Ok value out of the Result. If the
+/// result contains an Err, the empty .{} value is returned.
 Result.unwrap_or_default :: (r: #Self) -> r.Ok_Type {
     return switch r {
         case .Ok as v => v;
@@ -82,10 +76,8 @@ Result.unwrap_or_default :: (r: #Self) -> r.Ok_Type {
     };
 }
 
-#doc """
-    Tries to extract the Ok value out of the Result. If the
-    result contains an Err, a custom assertion message is thrown.
-"""
+/// Tries to extract the Ok value out of the Result. If the
+/// result contains an Err, a custom assertion message is thrown.
 Result.expect :: (r: #Self, msg: str) -> r.Ok_Type {
     switch r {
         case .Ok as v do return v;
@@ -96,11 +88,9 @@ Result.expect :: (r: #Self, msg: str) -> r.Ok_Type {
     }
 }
 
-#doc """
-    Returns a new result defined by:
-        Ok(n)  => Ok(f(n))
-        Err(e) => Err(e)
-"""
+/// Returns a new result defined by:
+///     Ok(n)  => Ok(f(n))
+///     Err(e) => Err(e)
 Result.transform :: (r: Result($T, $E), f: (T) -> $R) -> Result(R, E) {
     return switch r {
         case .Ok as v => .{ Ok = f(v) };
@@ -108,7 +98,7 @@ Result.transform :: (r: Result($T, $E), f: (T) -> $R) -> Result(R, E) {
     };
 }
 
-#doc "Monadic chaining operation."
+/// Monadic chaining operation.
 Result.and_then :: (r: #Self, f: (r.Ok_Type) -> Result($R, r.Err_Type)) -> Result(R, r.Err_Type) {
     return switch r {
         case .Ok as v  => f(v);
@@ -116,7 +106,7 @@ Result.and_then :: (r: #Self, f: (r.Ok_Type) -> Result($R, r.Err_Type)) -> Resul
     };
 }
 
-#doc "If the Result contains Err, generate is called to make a value"
+/// If the Result contains Err, generate is called to make a value
 Result.or_else :: (r: #Self, generate: () -> typeof r) => {
     return switch r {
         case .Ok as v   => v;
@@ -124,22 +114,20 @@ Result.or_else :: (r: #Self, generate: () -> typeof r) => {
     };
 }
 
-#doc """
-    If result contains Err, the error is returned from the enclosing
-    procedure. Otherwise, the Ok value is returned.
-
-        f :: () -> Result(i32, str) {
-            return .{ Err = "Oh no..." };
-        }
-        
-        g :: () -> Result(str, str) {
-            // This returns from g with the error returned from f.
-            v := f()->forward_err();
-            println(v);
-            
-            return .{ Ok = "Success!" };
-        }
-"""
+/// If result contains Err, the error is returned from the enclosing
+/// procedure. Otherwise, the Ok value is returned.
+///
+///     f :: () -> Result(i32, str) {
+///         return .{ Err = "Oh no..." };
+///     }
+///     
+///     g :: () -> Result(str, str) {
+///         // This returns from g with the error returned from f.
+///         v := f()->forward_err();
+///         println(v);
+///         
+///         return .{ Ok = "Success!" };
+///     }
 Result.forward_err :: macro (r: Result($T, $E)) -> T {
     switch res := r; res {
         case .Ok as v  do return v;
@@ -147,9 +135,7 @@ Result.forward_err :: macro (r: Result($T, $E)) -> T {
     }
 }
 
-#doc """
-    If result contains Err, the error is mapped to a new error type.
-"""
+/// If result contains Err, the error is mapped to a new error type.
 Result.transform_err :: macro (r: Result($T, $E), f: (E) -> $N) -> Result(T, N) {
     switch res := r; res {
         case .Ok  as v do return .{ Ok = v };
@@ -157,10 +143,8 @@ Result.transform_err :: macro (r: Result($T, $E), f: (E) -> $N) -> Result(T, N) 
     }
 }
 
-#doc """
-    If result contains Err, the given value is returned from the
-    enclosing procedure. Otherwise, the Ok value is returned.
-"""
+/// If result contains Err, the given value is returned from the
+/// enclosing procedure. Otherwise, the Ok value is returned.
 Result.or_return :: macro (r: Result($T, $E), v: $V) -> T {
     switch res := r; res {
         case .Ok as v  do return v;
@@ -168,14 +152,12 @@ Result.or_return :: macro (r: Result($T, $E), v: $V) -> T {
     }
 }
 
-#doc """
-    If result contains Err, the given code is run. This code is
-    expected to either:
-    - Return a good value with `return`
-    - Return an error value with `return return`
-
-    This procedure is subject to change.
-"""
+/// If result contains Err, the given code is run. This code is
+/// expected to either:
+/// - Return a good value with `return`
+/// - Return an error value with `return return`
+///
+/// This procedure is subject to change.
 Result.catch :: macro (r: Result($T, $E), on_err: Code) -> T {
     switch res := r; res {
         case .Ok as v  do return v;

--- a/core/container/slice.onyx
+++ b/core/container/slice.onyx
@@ -12,42 +12,36 @@ use core.memory
 // }
 //
 
-#doc """
-    Creates a zeroed slice of type `T` and length `length`, using the allocator provided.
-
-        use core {slice, println}
-
-        sl := slice.make(i32, 10);
-        println(sl);
-        // 0 0 0 0 0 0 0 0 0 0
-"""
+/// Creates a zeroed slice of type `T` and length `length`, using the allocator provided.
+///
+///     use core {slice, println}
+///
+///     sl := slice.make(i32, 10);
+///     println(sl);
+///     // 0 0 0 0 0 0 0 0 0 0
 Slice.make :: ($T: type_expr, length: u32, allocator := context.allocator) -> [] T {
     data := raw_alloc(allocator, sizeof T * length);
     memory.set(data, 0, sizeof T * length);
     return .{ data, length };
 }
 
-#doc """
-    Initializes a slice of type `T` to have a length of `length`, using the allocator provided.
-
-        use core {slice, println}
-
-        sl: [] i32;
-        slice.init(&sl, 10);
-        println(sl);
-        // 0 0 0 0 0 0 0 0 0 0
-"""
+/// Initializes a slice of type `T` to have a length of `length`, using the allocator provided.
+///
+///     use core {slice, println}
+///
+///     sl: [] i32;
+///     slice.init(&sl, 10);
+///     println(sl);
+///     // 0 0 0 0 0 0 0 0 0 0
 Slice.init :: (sl: &[] $T, length: u32, allocator := context.allocator) {
     sl.count = length;
     sl.data = raw_alloc(allocator, sizeof T * length);
     memory.set(sl.data, 0, sizeof T * length);
 }
 
-#doc """
-    Frees the data inside the slice.
-    The slice is taken by pointer because this procedure also sets the data pointer to `null`, and the length to `0`,
-    to prevent accidental future use of the slice.
-"""
+/// Frees the data inside the slice.
+/// The slice is taken by pointer because this procedure also sets the data pointer to `null`, and the length to `0`,
+/// to prevent accidental future use of the slice.
 Slice.free :: (sl: &[] $T, allocator := context.allocator) {
     if sl.data == null do return;
 
@@ -75,9 +69,7 @@ builtin.delete :: macro (x: &[] $T, allocator := context.allocator) {
 }
 
 
-#doc """
-    Copies a slice to a new slice, allocated from the provided allocator.
-"""
+/// Copies a slice to a new slice, allocated from the provided allocator.
 Slice.copy :: (sl: [] $T, allocator := context.allocator) -> [] T {
     data := raw_alloc(allocator, sl.count * sizeof T);
     memory.copy(data, sl.data, sl.count * sizeof T);
@@ -86,19 +78,17 @@ Slice.copy :: (sl: [] $T, allocator := context.allocator) -> [] T {
 }
 
 
-#doc """
-    Moves an element to a new index, ensuring that order of other elements is retained.
-
-        use core {slice, println}
-
-        arr := i32.[1, 2, 3, 4, 5, 6, 7, 8, 9, 10];
-
-        // Move element at index 4 to index 8
-        slice.transplant(arr, 4, 8);
-
-        println(arr);
-        // 1 2 3 4 6 7 8 9 5 10
-"""
+/// Moves an element to a new index, ensuring that order of other elements is retained.
+///
+///     use core {slice, println}
+///
+///     arr := i32.[1, 2, 3, 4, 5, 6, 7, 8, 9, 10];
+///
+///     // Move element at index 4 to index 8
+///     slice.transplant(arr, 4, 8);
+///
+///     println(arr);
+///     // 1 2 3 4 6 7 8 9 5 10
 Slice.transplant :: (arr: [] $T, old_index: i32, new_index: i32) -> bool {
     if old_index < 0 || old_index >= arr.count do return false;
     if new_index < 0 || new_index >= arr.count do return false;
@@ -123,9 +113,7 @@ Slice.transplant :: (arr: [] $T, old_index: i32, new_index: i32) -> bool {
     return true;
 }
 
-#doc """
-    Get an element from a slice, with negative and wrap-around indexing.
-"""
+/// Get an element from a slice, with negative and wrap-around indexing.
 Slice.get :: (arr: [] $T, idx: i32) -> T {
     if arr.count == 0 do return .{};
 
@@ -135,9 +123,7 @@ Slice.get :: (arr: [] $T, idx: i32) -> T {
     return arr.data[idx];
 }
 
-#doc """
-    Get a pointer to an element from a slice, with negative and wrap-around indexing.
-"""
+/// Get a pointer to an element from a slice, with negative and wrap-around indexing.
 Slice.get_ptr :: (arr: [] $T, idx: i32) -> &T {
     if arr.count == 0 do return null;
 
@@ -147,9 +133,7 @@ Slice.get_ptr :: (arr: [] $T, idx: i32) -> &T {
     return &arr.data[idx];
 }
 
-#doc """
-    Set a value in a slice, with negative and wrap-around indexing.
-"""
+/// Set a value in a slice, with negative and wrap-around indexing.
 Slice.set :: (arr: [] $T, idx: i32, value: T) {
     if arr.count == 0 do return;
 
@@ -171,39 +155,35 @@ Slice.contains :: #match #locked {
     }
 }
 
-#doc """
-    Tests if the slice is empty.
-
-    Normally this is unneeded, as arrays have a 'truthiness'
-    that depends on their count. For example, instead of saying:
-
-        if slice.empty(arr) { ... }
-
-    You can simply say:
-
-        if !arr { ... }
-"""
+/// Tests if the slice is empty.
+///
+/// Normally this is unneeded, as arrays have a 'truthiness'
+/// that depends on their count. For example, instead of saying:
+///
+///     if slice.empty(arr) { ... }
+///
+/// You can simply say:
+///
+///     if !arr { ... }
 Slice.empty :: (arr: [] $T) => arr.count == 0;
 
-#doc "Uses `+` to sum all elements in the slice."
+/// Uses `+` to sum all elements in the slice.
 Slice.sum :: (arr: [] $T, start: T = 0) -> T {
     sum := start;
     for it in arr do sum += it;
     return sum;
 }
 
-#doc "Uses `*` to multiply all elements in the slice."
+/// Uses `*` to multiply all elements in the slice.
 Slice.product :: (arr: [] $T, start: T = 1) -> T {
     prod := start;
     for it in arr do prod *= it;
     return prod;
 }
 
-#doc """
-    Uses `+` to add the elements together.
-    Then use `/ i32` to divide by the number of elements.
-    Both of these are assumed to work.
-"""
+/// Uses `+` to add the elements together.
+/// Then use `/ i32` to divide by the number of elements.
+/// Both of these are assumed to work.
 Slice.average :: (arr: [] $T) -> T {
     sum := cast(T) 0;
     for it in *arr do sum += it;
@@ -211,9 +191,7 @@ Slice.average :: (arr: [] $T) -> T {
     return sum / cast(T) arr.count;
 }
 
-#doc """
-    Reverses a slice in-place.
-"""
+/// Reverses a slice in-place.
 Slice.reverse :: (arr: [] $T) {
     for i in arr.count / 2 {
         tmp := arr[i];
@@ -222,15 +200,13 @@ Slice.reverse :: (arr: [] $T) {
     }
 }
 
-#doc """
-    Simple insertion sort.
-    
-    `cmp` should return greater-than 0 if `left > right`.
-
-    Returns the array to be used in '|>' chaining.
-
-    **Not a copy of the slice.**
-"""
+/// Simple insertion sort.
+/// 
+/// `cmp` should return greater-than 0 if `left > right`.
+///
+/// Returns the array to be used in '|>' chaining.
+///
+/// **Not a copy of the slice.**
 Slice.sort :: #match #local {}
 
 #overload
@@ -277,11 +253,9 @@ Slice.sort :: (arr: [] $T, cmp: (&T, &T) -> i32) -> [] T {
     return arr;
 }
 
-#doc """
-    Quicksort a slice.
-
-    `cmp` should return greater-than 0 if `left > right`.
-"""
+/// Quicksort a slice.
+///
+/// `cmp` should return greater-than 0 if `left > right`.
 Slice.quicksort :: #match #locked {
     (arr: [] $T, cmp: ( T,  T) -> i32) => { quicksort_impl(arr, cmp, 0, arr.count - 1); return arr; },
     (arr: [] $T, cmp: (&T, &T) -> i32) => { quicksort_impl(arr, cmp, 0, arr.count - 1); return arr; },
@@ -334,13 +308,11 @@ Slice.quicksort :: #match #locked {
     }
 }
 
-#doc """
-    Shrinks a slice, removing all duplicates of elements, using `==`
-    to compare elements.
-
-    This assumes that the elements are sorted in some fashion,
-    such that equal elements would be next to each other.
-"""
+/// Shrinks a slice, removing all duplicates of elements, using `==`
+/// to compare elements.
+///
+/// This assumes that the elements are sorted in some fashion,
+/// such that equal elements would be next to each other.
 Slice.unique :: (arr: &[] $T) {
     idx := 0;
     while i := 0; i < arr.count - 1 {
@@ -360,19 +332,17 @@ Slice.unique :: (arr: &[] $T) {
 }
 
 
-#doc """
-    Reduces a slice down to a single value, using successive calls to `f`, or invokations of the `body`.
-
-        use core {slice, println}
-
-        arr := i32.[1, 2, 3, 4, 5];
-
-        slice.fold(arr, 0, (it, acc) => it + acc) |> println();
-
-        // OR
-
-        slice.fold(arr, 0, [it, acc](it + acc)) |> println();
-"""
+/// Reduces a slice down to a single value, using successive calls to `f`, or invokations of the `body`.
+///
+///     use core {slice, println}
+///
+///     arr := i32.[1, 2, 3, 4, 5];
+///
+///     slice.fold(arr, 0, (it, acc) => it + acc) |> println();
+///     
+///     // OR
+///     
+///     slice.fold(arr, 0, [it, acc](it + acc)) |> println();
 Slice.fold :: #match #local {}
 
 #overload
@@ -389,9 +359,7 @@ Slice.fold :: macro (arr: [] $T, init: $R, body: Code) -> R {
     return acc;
 }
 
-#doc """
-    Returns `true` if *every* element in the slice meets the predicate test.
-"""
+/// Returns `true` if *every* element in the slice meets the predicate test.
 Slice.every :: #match #local {}
 
 #overload
@@ -405,9 +373,7 @@ Slice.every :: macro (arr: [] $T, predicate_body: Code) -> bool {
     return true;
 }
 
-#doc """
-    Returns `true` if *at least one* element in the slice meets the predicate test.
-"""
+/// Returns `true` if *at least one* element in the slice meets the predicate test.
 Slice.some :: #match #local {}
 
 #overload
@@ -429,18 +395,14 @@ Slice.some :: macro (arr: [] $T, predicate_body: Code) -> bool {
     return false;
 }
 
-#doc """
-    Sets all elements in a slice to be `value`.
-"""
+/// Sets all elements in a slice to be `value`.
 Slice.fill :: (arr: [] $T, value: T) {
     for i in arr.count {
         arr[i] = value;
     }
 }
 
-#doc """
-    Sets all elements in the range to be `value`.
-"""
+/// Sets all elements in the range to be `value`.
 Slice.fill_range :: (arr: [] $T, r: range, value: T) {
     for i in r {
         if i >= arr.count || i < 0 do continue;
@@ -448,9 +410,7 @@ Slice.fill_range :: (arr: [] $T, r: range, value: T) {
     }
 }
 
-#doc """
-    Converts a slice to a linked list.
-"""
+/// Converts a slice to a linked list.
 Slice.to_list :: (arr: [] $T, allocator := context.allocator) -> List(T) {
     new_list := list.make(T, allocator);
 
@@ -461,11 +421,9 @@ Slice.to_list :: (arr: [] $T, allocator := context.allocator) -> List(T) {
     return new_list;
 }
 
-#doc """
-    Returns the index of the first element that matches the predicate.
-
-    Returns `-1` if no matching element is found.
-"""
+/// Returns the index of the first element that matches the predicate.
+///
+/// Returns `-1` if no matching element is found.
 Slice.find :: #match #local {}
 
 #overload
@@ -497,11 +455,9 @@ Slice.find :: macro (arr: [] $T, pred: Code) -> i32 {
     return -1;
 }
 
-#doc """
-    Returns a pointer to the first element that equals `value`, compared using `==`.
-
-    Returns `null` if no matching element is found.
-"""
+/// Returns a pointer to the first element that equals `value`, compared using `==`.
+///
+/// Returns `null` if no matching element is found.
 Slice.find_ptr :: (arr: [] $T, value: T) -> &T {
     for &it in arr {
         if value == *it do return it;
@@ -510,9 +466,7 @@ Slice.find_ptr :: (arr: [] $T, value: T) -> &T {
     return null;
 }
 
-#doc """
-    
-"""
+/// Returns an optional of the first element that the code block evaluates to a truthy value.
 Slice.find_opt :: #match {
     macro (arr: [] $T/type_is_struct, cond: Code) -> ? T {
         for& it in arr {
@@ -559,9 +513,7 @@ Slice.first :: #match #locked {
     }
 }
 
-#doc """
-    Returns the number of elements for which the predicate is true.
-"""
+/// Returns the number of elements for which the predicate is true.
 Slice.count_where :: #match #local {}
 
 #overload
@@ -577,9 +529,7 @@ Slice.count_where :: macro (arr: [] $T, predicate_body: Code) -> u32 {
 }
 
 
-#doc """
-    Creates an iterator of a sliding window over the elements of the slice, with width `width`.
-"""
+/// Creates an iterator of a sliding window over the elements of the slice, with width `width`.
 Slice.windows :: (arr: [] $T, width: i32) -> Iterator([] T) {
     use core {iter}
 
@@ -596,10 +546,8 @@ Slice.windows :: (arr: [] $T, width: i32) -> Iterator([] T) {
     );
 }
 
-#doc """
-    Creates an iterator of chunks over the elements of the slice.
-    Each chunk has size `width`, with the last chunk having size `arr.count % width`.
-"""
+/// Creates an iterator of chunks over the elements of the slice.
+/// Each chunk has size `width`, with the last chunk having size `arr.count % width`.
 Slice.chunks :: (arr: [] $T, width: i32) -> Iterator([] T) {
     use core {iter}
 
@@ -619,13 +567,11 @@ Slice.chunks :: (arr: [] $T, width: i32) -> Iterator([] T) {
 }
 
 
-#doc """
-    Groups a slice into sub-slices using the comparison function.
-
-    `comp` should evaluate to a boolean value.
-
-    Expects slice to sorted so all equal values are next to each other.
-"""
+/// Groups a slice into sub-slices using the comparison function.
+///
+/// `comp` should evaluate to a boolean value.
+///
+/// Expects slice to sorted so all equal values are next to each other.
 Slice.group_by :: #match #local {}
 
 #overload
@@ -685,17 +631,13 @@ Slice.equal :: (arr1: [] $T/HasEquals, arr2: [] T) -> bool {
     return idx, elem;
 }
 
-#doc """
-    Returns the largest element in the array, using `>` to compare.
-"""
+/// Returns the largest element in the array, using `>` to compare.
 Slice.greatest :: macro (arr: [] $T) -> (i32, T) {
     fold_idx_elem :: fold_idx_elem
     return fold_idx_elem(arr, [](*A > *B));
 }
 
-#doc """
-    Returns the smallest element in the array, using `<` to compare.
-"""
+/// Returns the smallest element in the array, using `<` to compare.
 Slice.least :: macro (arr: [] $T) -> (i32, T) {
     fold_idx_elem :: fold_idx_elem
     return fold_idx_elem(arr, [](*A < *B));

--- a/core/conv/conv.onyx
+++ b/core/conv/conv.onyx
@@ -7,11 +7,9 @@ package core.conv
 use core.string
 use core.math
 
-#doc """
-    Converts a string into an integer. Works with positive and
-    negative integers. If given a pointer to a string, will
-    modify the string to extract the integer part.
-"""
+/// Converts a string into an integer. Works with positive and
+/// negative integers. If given a pointer to a string, will
+/// modify the string to extract the integer part.
 str_to_i64 :: #match #local {}
 
 #overload
@@ -68,7 +66,7 @@ str_to_i64 :: (s: &str, base: u32 = 10) -> i64 {
 }
 
 
-#doc "Converts a string to a floating point number."
+/// Converts a string to a floating point number.
 str_to_f64 :: #match #local {}
 
 #overload
@@ -142,12 +140,10 @@ str_to_f64 :: (s: &str) -> f64 {
 }
 
 
-#doc """
-    Converts an integer into a string using the buffer provided.
-    Supports upto base 64. If prefix is true, binary numbers are
-    prefixed with '0b' and hexadecimal numbers are prefixed with
-    '0x'.
-"""
+/// Converts an integer into a string using the buffer provided.
+/// Supports upto base 64. If prefix is true, binary numbers are
+/// prefixed with '0b' and hexadecimal numbers are prefixed with
+/// '0x'.
 i64_to_str :: (n: i64, base: u64, buf: [] u8, min_length := 0, prefix := false) -> str {
     is_neg := false;
     if n < 0 {
@@ -213,10 +209,8 @@ i64_to_str :: (n: i64, base: u64, buf: [] u8, min_length := 0, prefix := false) 
 }
 
 
-#doc """
-    Converts an unsigned number into a string using the buffer provided.
-    Behaves like i64_to_str.
-"""
+/// Converts an unsigned number into a string using the buffer provided.
+/// Behaves like i64_to_str.
 u64_to_str :: (n: u64, base: u64, buf: [] u8, min_length := 0, prefix := false) -> str {
     c: [&] u8 = &buf[buf.count - 1];
     len := 0;
@@ -269,13 +263,11 @@ u64_to_str :: (n: u64, base: u64, buf: [] u8, min_length := 0, prefix := false) 
     return str.{ data = c + 1, count = len };
 }
 
-#doc """
-    Converts a floating point number into a string, using
-    the buffer provided.
-   
-    This is better than what used to be, but still relies on converting the integer
-    part of the float to an integer, which could overflow.
-"""
+/// Converts a floating point number into a string, using
+/// the buffer provided.
+///
+/// This is better than what used to be, but still relies on converting the integer
+/// part of the float to an integer, which could overflow.
 f64_to_str :: (f: f64, buf: [] u8, digits_after_decimal := 4) -> str {
     if math.is_nan(f) {
         return format(buf, "NaN");

--- a/core/conv/format.onyx
+++ b/core/conv/format.onyx
@@ -12,11 +12,9 @@ use runtime
     custom_parsers   : Map(type_expr, #type (rawptr, str, Allocator) -> bool);
 }
 
-#doc """
-    This procedure is run before main() as it is an #init procedure.
-    It looks for all custom formatting and parsing definitions and
-    registers them to be used in format_any and parse_any.
-"""
+/// This procedure is run before main() as it is an #init procedure.
+/// It looks for all custom formatting and parsing definitions and
+/// registers them to be used in format_any and parse_any.
 custom_formatters_initialized :: #init () {
     map.init(&custom_formatters);
     map.init(&custom_parsers);
@@ -61,76 +59,61 @@ custom_formatters_initialized :: #init () {
     }
 }
 
-#doc """
-    Registers a formatting function for a particular type. This type is
-    inferred from the type of the third argument in the given function.
-"""
+/// Registers a formatting function for a particular type. This type is
+/// inferred from the type of the third argument in the given function.
 register_custom_formatter :: (formatter: (&Format_Output, &Format, &$T) -> void) {
     custom_formatters[T] = formatter;
 }
 
 
-#doc """
-    Registers a parsing function for a particular type. This type is
-    inferred from the type of the first argument in the given function.
-"""
+/// Registers a parsing function for a particular type. This type is
+/// inferred from the type of the first argument in the given function.
 register_custom_parser :: (parser: (&$T, str, Allocator) -> bool) {
     custom_parsers[T] = parser;
 }
 
 
-#doc """
-    Tag-type used to specify how to format a structure.
-   
-        @conv.Custom_Format.{ format_structure }
-        TheStructure :: struct { ... }
-"""
+/// Tag-type used to specify how to format a structure.
+///
+///     @conv.Custom_Format.{ format_structure }
+///     TheStructure :: struct { ... }
 Custom_Format :: struct {
     format: (&Format_Output, &Format, rawptr) -> void;
 }
 
 
-#doc """
-    Tag-type used to specify that a certain procedure should be used
-    to format a type.
-   
-        @conv.Custom_Format_Proc.{ TheStructure }
-        format_structure :: (output: &conv.Format_Output, format: &conv.Format, data: &TheStructure) { ... }
-"""
+/// Tag-type used to specify that a certain procedure should be used
+/// to format a type.
+///
+///     @conv.Custom_Format_Proc.{ TheStructure }
+///     format_structure :: (output: &conv.Format_Output, format: &conv.Format, data: &TheStructure) { ... }
 Custom_Format_Proc :: struct {
     type: type_expr;
 }
 
 
-#doc """
-    Tag-type used to specify how to parse a structure.
-   
-        @conv.Custom_Parse.{ parse_structure }
-        TheStructure :: struct { ... }
-"""
+/// Tag-type used to specify how to parse a structure.
+///
+///     @conv.Custom_Parse.{ parse_structure }
+///     TheStructure :: struct { ... }
 Custom_Parse :: struct {
     parse: (rawptr, str, Allocator) -> bool;
 }
 
 
-#doc """
-    Tag-type used to specify that a certain procedure should be used
-    to parse a type.
-   
-        @conv.Custom_Parse_Proc.{ TheStructure }
-        parse_structure :: (data: &TheStructure, input: str, allocator: Allocator) -> bool { ... }
-   
-"""
+/// Tag-type used to specify that a certain procedure should be used
+/// to parse a type.
+///
+///     @conv.Custom_Parse_Proc.{ TheStructure }
+///     parse_structure :: (data: &TheStructure, input: str, allocator: Allocator) -> bool { ... }
 Custom_Parse_Proc :: struct {
     type: type_expr;
 }
 
-#doc """
-    Passed to any custom formatter. Wraps outputting data to any source,
-    using a `flush` callback function. Use `write` to output a string.
-    When the internal buffer is filled, `flush` is called to empty the
-    buffer to the final destination.
-"""
+/// Passed to any custom formatter. Wraps outputting data to any source,
+/// using a `flush` callback function. Use `write` to output a string.
+/// When the internal buffer is filled, `flush` is called to empty the
+/// buffer to the final destination.
 Format_Output :: struct {
     data: [&] u8;
     count: u32;
@@ -174,7 +157,7 @@ Format_Flush_Callback :: struct {
 }
 
 
-#doc "Formatting options passed to a custom formatter."
+/// Formatting options passed to a custom formatter.
 Format :: struct {
     pretty_printing      := false;        // p
     quote_strings        := false;        // "
@@ -212,10 +195,8 @@ builtin.logf :: (level: builtin.Log_Level, format: str, va: ..any) {
 }
 
 
-#doc """
-    Formats a string using the provided arguments and format specified string.
-    This has many overloads to make it easy to work with.
-"""
+/// Formats a string using the provided arguments and format specified string.
+/// This has many overloads to make it easy to work with.
 format :: #match {}
 
 #overload
@@ -247,9 +228,7 @@ format :: (buffer: &dyn_str, format: str, va: ..any) -> str {
     return *buffer;
 }
 
-#doc """
-    Like `format`, but takes the arguments as an array of `any`s, not a variadic argument array.
-"""
+/// Like `format`, but takes the arguments as an array of `any`s, not a variadic argument array.
 format_va :: #match {}
 
 #overload
@@ -416,11 +395,9 @@ format_va :: (output: &Format_Output, format: str, va: [] any) -> str {
 }
 
 
-#doc """
-    This procedure converts any value into a string, using the type information system.
-    If a custom formatter is specified for the type, that is used instead.
-    This procedure is generally not used directly; instead, through format or format_va.
-"""
+/// This procedure converts any value into a string, using the type information system.
+/// If a custom formatter is specified for the type, that is used instead.
+/// This procedure is generally not used directly; instead, through format or format_va.
 format_any :: (output: &Format_Output, formatting: &Format, v: any) {
     use runtime.info {*};
 

--- a/core/conv/parse.onyx
+++ b/core/conv/parse.onyx
@@ -7,10 +7,8 @@ use core.math
 use core.memory
 use runtime
 
-#doc """
-    Parses many different types from a string into a value.
-    Uses a custom parser if one has been specified for the type given.
-"""
+/// Parses many different types from a string into a value.
+/// Uses a custom parser if one has been specified for the type given.
 parse_any :: #match {}
 
 #overload
@@ -123,9 +121,7 @@ parse_any :: (target: rawptr, data_type: type_expr, to_parse: str, string_alloca
 }
 
 
-#doc """
-    Shortcut to parse a type `T` using `parse_any`.
-"""
+/// Shortcut to parse a type `T` using `parse_any`.
 parse :: ($T: type_expr, to_parse: str) -> ? T {
     v: T;
     if #this_package.parse_any(&v, to_parse) {
@@ -135,9 +131,7 @@ parse :: ($T: type_expr, to_parse: str) -> ? T {
     }
 }
 
-#doc """
-    Shortcut to parse a type `T` using `parse_any`, and specify an allocator.
-"""
+/// Shortcut to parse a type `T` using `parse_any`, and specify an allocator.
 parse_with_allocator :: ($T: type_expr, to_parse: str, allocator: Allocator) -> ? T {
     v: T;
     if #this_package.parse_any(&v, to_parse, allocator) {

--- a/core/encoding/base64.onyx
+++ b/core/encoding/base64.onyx
@@ -1,20 +1,19 @@
+///
+/// A simple Base64 encoding and decoding library. Currently
+/// only supports base64 with + and / characters. A simple
+/// find and replace could be used to change to other base64
+/// standards.
+///
+
 package core.encoding.base64
 #allow_stale_code
 
 use core.array
 
-//
-// A simple Base64 encoding and decoding library. Currently
-// only supports base64 with + and / characters. A simple
-// find and replace could be used to change to other base64
-// standards.
-//
 
-#doc """
-    Encodes the given data in base64 into a new buffer, allocated
-    from the allocator provided. It is the callers responsibilty
-    to free this memory.
-"""
+/// Encodes the given data in base64 into a new buffer, allocated
+/// from the allocator provided. It is the callers responsibilty
+/// to free this memory.
 encode :: (data: [] u8, allocator := context.allocator) -> [] u8 {
     out := array.make(u8, allocator=allocator);
 
@@ -48,10 +47,8 @@ encode :: (data: [] u8, allocator := context.allocator) -> [] u8 {
     return out;
 }
 
-#doc """
-    Decodes the given base64 data into a new buffer, allocated
-    from the allocator provided.
-"""
+/// Decodes the given base64 data into a new buffer, allocated
+/// from the allocator provided.
 decode :: (data: [] u8, allocator := context.allocator) -> [] u8 {
     if data.count % 4 != 0 do return null_str;
 

--- a/core/encoding/csv.onyx
+++ b/core/encoding/csv.onyx
@@ -25,25 +25,23 @@ use runtime.info {
     Type_Info_Struct
 }
 
-#doc "Represents data from a CSV file of a particular type."
+/// Represents data from a CSV file of a particular type.
 CSV :: struct (Output_Type: type_expr) {
     entries: [..] Output_Type;
 }
 
-#doc """
-    Tag-type used to tell the ingress and egress methods what
-    the column name of a particular data element should be.
-
-        Data :: struct {
-            @CSV_Column.{"Actual Column Name"}
-            variable_name: str;
-        }
-"""
+/// Tag-type used to tell the ingress and egress methods what
+/// the column name of a particular data element should be.
+///
+///     Data :: struct {
+///         @CSV_Column.{"Actual Column Name"}
+///         variable_name: str;
+///     }
 CSV_Column :: struct {
     name: str;
 }
 
-#doc "Create and initialize a CSV with no elements."
+/// Create and initialize a CSV with no elements.
 CSV.make :: ($T: type_expr) => {
     r := CSV(T).{};
     r.entries = make(typeof r.entries);
@@ -51,19 +49,17 @@ CSV.make :: ($T: type_expr) => {
     return r;
 }
 
-#doc "Frees all data in a CSV."
+/// Frees all data in a CSV.
 CSV.delete :: (csv: &CSV) {
     delete(&csv.entries);
 }
 
-#doc """
-    Ingests data from a string representing CSV data.
-    Uses the type of the CSV to know what columns should be expected.
-    If `headers_presents` is true, the first line will be treated as
-    headers, and cross checked with the CSV_Column tag information.
-    Use this when the columns from your CSV have a different order
-    from the order of fields in the structure.
-"""
+/// Ingests data from a string representing CSV data.
+/// Uses the type of the CSV to know what columns should be expected.
+/// If `headers_presents` is true, the first line will be treated as
+/// headers, and cross checked with the CSV_Column tag information.
+/// Use this when the columns from your CSV have a different order
+/// from the order of fields in the structure.
 CSV.ingress_string :: (csv: &CSV, contents: str, headers_present := true) -> bool {
     reader, stream := io.reader_from_string(contents);
     defer cfree(stream);
@@ -71,10 +67,8 @@ CSV.ingress_string :: (csv: &CSV, contents: str, headers_present := true) -> boo
     return csv->ingress(&reader, headers_present);
 }
 
-#doc """
-    Ingests data from a Reader containing CSV data.
-    Uses the type of the CSV to know what columns should be expectd.
-"""
+/// Ingests data from a Reader containing CSV data.
+/// Uses the type of the CSV to know what columns should be expectd.
 CSV.ingress :: (csv: &CSV, reader: &io.Reader, headers_present := true) -> bool {
     Header :: struct {
         type: type_expr;
@@ -132,11 +126,9 @@ CSV.ingress :: (csv: &CSV, reader: &io.Reader, headers_present := true) -> bool 
     return true;
 }
 
-#doc """
-    Outputs data from a CSV into a Writer.
-    When `include_headers` is true, the first line outputted will be
-    the headers of the CSV, according to the CSV_Column tag information.
-"""
+/// Outputs data from a CSV into a Writer.
+/// When `include_headers` is true, the first line outputted will be
+/// the headers of the CSV, according to the CSV_Column tag information.
 CSV.egress :: (csv: &CSV, writer: &io.Writer, include_headers := true) {
     output_type_info: &Type_Info_Struct = ~~ get_type_info(csv.Output_Type);
 

--- a/core/encoding/json/decoder.onyx
+++ b/core/encoding/json/decoder.onyx
@@ -3,12 +3,10 @@ package core.encoding.json
 
 use core {*}
 
-#doc """
-    Unsafely decodes a strings into a json object, returning an invalid
-    Json value if it failed to parse.
-
-    This procedure is not very useful and should be considered deprecated.
-"""
+/// Unsafely decodes a strings into a json object, returning an invalid
+/// Json value if it failed to parse.
+///
+/// This procedure is not very useful and should be considered deprecated.
 decode :: (data: str, allocator := context.allocator, print_errors := true) -> Json {
     json: Json;
     json.allocator = allocator;
@@ -42,12 +40,10 @@ Decode_Error.has_error :: (this: Decode_Error) => cast(^_Decode_Error) this != n
 Decode_Error.message   :: (this: Decode_Error) => (cast(^_Decode_Error) this).errmsg;
 Decode_Error.position  :: (this: Decode_Error) => (cast(^_Decode_Error) this).pos;
 
-#doc """
-    Decodes a string into a Json object, and returns the Json object and
-    and a `Decode_Error` that is non-null if an error occured.
-
-    This procedure should be considered deprecated in favor of `decode_with_result`.
-"""
+/// Decodes a string into a Json object, and returns the Json object and
+/// and a `Decode_Error` that is non-null if an error occured.
+///
+/// This procedure should be considered deprecated in favor of `decode_with_result`.
 decode_with_error :: (data: str, allocator := context.allocator) -> (Json, Decode_Error) {
     json: Json;
     json.allocator = allocator;
@@ -72,9 +68,7 @@ decode_with_error :: (data: str, allocator := context.allocator) -> (Json, Decod
     return json, Decode_Error.{null};
 }
 
-#doc """
-    Decodes a string into a possible Json object. If parsing fails, an error is returned instead.
-"""
+/// Decodes a string into a possible Json object. If parsing fails, an error is returned instead.
 decode_with_result :: (data: str, allocator := context.allocator) -> Result(Json, Error) {
     root, err := parse(data, allocator);
     if err.kind != .None {
@@ -86,11 +80,9 @@ decode_with_result :: (data: str, allocator := context.allocator) -> Result(Json
     };
 }
 
-#doc """
-    Decodes a string into any Onyx type.
-
-    Internally uses `decode_with_result` and `as_any`.
-"""
+/// Decodes a string into any Onyx type.
+///
+/// Internally uses `decode_with_result` and `as_any`.
 decode_into :: (data: str, out: &$T) -> Error {
     obj := decode_with_result(data)->catch([err] {
         return return err;

--- a/core/encoding/kdl/kdl.onyx
+++ b/core/encoding/kdl/kdl.onyx
@@ -45,9 +45,7 @@ KDL_Number :: union {
     String: str;
 }
 
-#doc """
-    Creates a new KDL document, using the allocator provided.
-"""
+/// Creates a new KDL document, using the allocator provided.
 new_doc :: (allocator := context.allocator) -> Document {
     doc: Document;
     doc.allocator = allocator;
@@ -56,11 +54,9 @@ new_doc :: (allocator := context.allocator) -> Document {
 }
 
 
-#doc """
-    Parses a string or `io.Reader` into a KDL document, using the allocator provided for internal allocations.
-
-    Call `core.encoding.kdl.free` to free the returned document.
-"""
+/// Parses a string or `io.Reader` into a KDL document, using the allocator provided for internal allocations.
+///
+/// Call `core.encoding.kdl.free` to free the returned document.
 parse :: #match #local -> Result(Document, Parse_Error) {}
 
 #overload
@@ -96,9 +92,7 @@ parse :: (r: &io.Reader, allocator := context.allocator) -> Result(Document, Par
 #overload
 builtin.delete :: free
 
-#doc """
-    Releases all resources allocated for the document.
-"""
+/// Releases all resources allocated for the document.
 free :: (d: Document) {
     for d.nodes do free_node(d.allocator, it);
     delete(&d.nodes);

--- a/core/hash/hash.onyx
+++ b/core/hash/hash.onyx
@@ -8,20 +8,18 @@ use core.intrinsics.types {type_is_enum}
 // core.hash.hash instead.
 to_u32 :: hash
 
-#doc """
-    This overloaded procedure defines how to hash something.
-    It is used throughout the standard library to hash values.
-    There are many overloads to it in the standard library, and
-    more can be added using #overload.
-
-    Alternatively, a hash method can be defined for a structure or distinct type.
-   
-        Person :: struct {
-            hash :: (p: Person) -> u32 {
-                return // ...
-            }
-        }
-"""
+/// This overloaded procedure defines how to hash something.
+/// It is used throughout the standard library to hash values.
+/// There are many overloads to it in the standard library, and
+/// more can be added using #overload.
+///
+/// Alternatively, a hash method can be defined for a structure or distinct type.
+///
+///     Person :: struct {
+///         hash :: (p: Person) -> u32 {
+///             return // ...
+///         }
+///     }
 hash :: #match -> u32 {
     // Does this need to have a higher precedence value?
     // Because if I wanted to have a custom type as the key

--- a/core/hash/md5.onyx
+++ b/core/hash/md5.onyx
@@ -5,17 +5,17 @@ use core {io, memory, conv}
 use core.intrinsics.wasm {rotl_i32}
 
 
-#doc "Produces an MD5 digest of a string or stream."
+/// Produces an MD5 digest of a string or stream.
 digest :: #match #local {}
 
-#doc "Produces an MD5 digest of a string. This is guaranteed to succeed."
+/// Produces an MD5 digest of a string. This is guaranteed to succeed.
 #overload
 digest :: (x: str) -> MD5_Digest {
     string_stream := io.buffer_stream_make(x, write_enabled=false);
     return digest(&string_stream)?;
 }
 
-#doc "Produces an MD5 digest of a stream. This is not guaranteed to succeed, as the stream may fail part way through."
+/// Produces an MD5 digest of a stream. This is not guaranteed to succeed, as the stream may fail part way through.
 #overload
 digest :: (s: &io.Stream) -> ?MD5_Digest {
     dig := MD5_Digest.make();
@@ -78,7 +78,7 @@ MD5_Digest._finish :: (self: &#Self, tail: [] u8) {
     do_cycle(self, bytes_to_digest, accumulate=false);
 }
 
-#doc "Returns a temporary byte array of the hash."
+/// Returns a temporary byte array of the hash.
 MD5_Digest.as_str :: (self: #Self) -> [] u8 {
     result := make_temp([] u8, 16);
     for i in 0  .. 4  do result[i] = ~~((self.a & (0xff << shift(i))) >> shift(i));
@@ -88,7 +88,7 @@ MD5_Digest.as_str :: (self: #Self) -> [] u8 {
     return result;
 }
 
-#doc "Returns a temporary string of the hash."
+/// Returns a temporary string of the hash.
 MD5_Digest.as_hex_str :: (self: #Self) -> str {
     result := make_temp([..] u8, 32);
     for i in 0  .. 4  do conv.format(&result, "{w2b16}", (self.a & (0xff << shift(i)) >> shift(i)));

--- a/core/io/stream.onyx
+++ b/core/io/stream.onyx
@@ -143,15 +143,13 @@ stream_size :: (use s: &Stream) -> i32 {
     return vtable.size(s);
 }
 
-#doc """
-    Waits until a stream is able to be read from or written to.
-
-    If `timeout` < 0, then there is an indefinite timeout.
-    
-    If `timeout` = 0, then there is no timeout, and this function returns immediately.
-
-    If `timeout` > 0, then there is a `timeout` millisecond delay before returning false.
-"""
+/// Waits until a stream is able to be read from or written to.
+///
+/// If `timeout` < 0, then there is an indefinite timeout.
+/// 
+/// If `timeout` = 0, then there is no timeout, and this function returns immediately.
+///
+/// If `timeout` > 0, then there is a `timeout` millisecond delay before returning false.
 stream_poll :: (use s: &Stream, ev: PollEvent, timeout: i32) -> (Error, bool) {
     if vtable == null do return .NoVtable, false;
     if vtable.poll == null_proc do return .NotImplemented, false;

--- a/core/js/func.onyx
+++ b/core/js/func.onyx
@@ -1,12 +1,12 @@
 
 package core.js
 
-#doc "Represents an Onyx function that can be called by JavaScript."
+/// Represents an Onyx function that can be called by JavaScript.
 Func :: #distinct Value
 
 func :: Func.from
 
-#doc "Creates a JavaScript function that wraps an Onyx function."
+/// Creates a JavaScript function that wraps an Onyx function.
 Func.from :: (f: (this: Value, args: [] Value) -> Value) -> Func {
     func := __make_func(f);
     __add_to_pool(cast(Value) func);

--- a/core/js/value.onyx
+++ b/core/js/value.onyx
@@ -6,9 +6,7 @@ use core.math
 use core.array
 use core.alloc
 
-#doc """
-    Used to represent a JavaScript value.
-"""
+/// Used to represent a JavaScript value.
 Value :: #distinct u64
 
 value :: Value.from
@@ -33,25 +31,23 @@ False      :: Value.{0x7ff8000000000004}
 Global     :: Value.{0x7ff8000000000005}
 Onyx       :: Value.{0x7ff8000000000006}
 
-#doc "Creates a new JavaScript object and returns the `Value` handle to it."
+/// Creates a new JavaScript object and returns the `Value` handle to it.
 Value.new_object :: () -> Value {
     v := __new_object();
     __add_to_pool(v);
     return v;
 }
 
-#doc "Creates a new JavaScript array and returns the `Value` handle to it."
+/// Creates a new JavaScript array and returns the `Value` handle to it.
 Value.new_array :: () -> Value {
     v := __new_array();
     __add_to_pool(v);
     return v;
 }
 
-#doc """
-    Converts an Onyx value into a JavaScript `Value`.
-
-    Currently, these types are supported: `i32`, `u32`, `i64`, `u64`, `f32`, `f64`, `bool`, str, `Value`, `Func`, and `Map(str, $V)`.
-"""
+/// Converts an Onyx value into a JavaScript `Value`.
+///
+/// Currently, these types are supported: `i32`, `u32`, `i64`, `u64`, `f32`, `f64`, `bool`, str, `Value`, `Func`, and `Map(str, $V)`.
 Value.from :: #match {
     (m: Map(str, $V)) -> ? Value {
         result := Value.new_object();
@@ -123,7 +119,7 @@ Value.from :: #match {
     }
 }
 
-#doc "Converts a `Value` into a `bool`. If the value is not internally of boolean type, `None` is returned."
+/// Converts a `Value` into a `bool`. If the value is not internally of boolean type, `None` is returned.
 Value.as_bool :: (v: Value) -> ? bool {
     if cast(u64) v == cast(u64) True  do return true;
     if cast(u64) v == cast(u64) False do return false;
@@ -131,7 +127,7 @@ Value.as_bool :: (v: Value) -> ? bool {
     return .None;
 }
 
-#doc "Converts a `Value` into a `f64`. If the value is not internally of float type, `None` is returned."
+/// Converts a `Value` into a `f64`. If the value is not internally of float type, `None` is returned.
 Value.as_float :: (v: Value) -> ? f64 {
     v_u64 := cast(u64, v);
     v_f64 := *cast(&f64, &v_u64);
@@ -142,7 +138,7 @@ Value.as_float :: (v: Value) -> ? f64 {
     return .None;
 }
 
-#doc "Converts a `Value` into a `i32`. If the value is not internally of float type, `None` is returned."
+/// Converts a `Value` into a `i32`. If the value is not internally of float type, `None` is returned.
 Value.as_int :: (v: Value) -> ? i32 {
     v_u64 := cast(u64, v);
     v_f64 := *cast(&f64, &v_u64);
@@ -153,12 +149,10 @@ Value.as_int :: (v: Value) -> ? i32 {
     return .None;
 }
 
-#doc """
-    Converts a `Value` into a `str`. If the value is not internally of str type, `None` is returned.
-
-    Note that this function returns a string that is allocated on the heap.
-    The caller is responsible for managing the returned string.
-"""
+/// Converts a `Value` into a `str`. If the value is not internally of str type, `None` is returned.
+///
+/// Note that this function returns a string that is allocated on the heap.
+/// The caller is responsible for managing the returned string.
 Value.as_str :: (v: Value) -> ? str {
     len := __to_str(v, .[]);
     if len < 0 do return .None;
@@ -168,9 +162,7 @@ Value.as_str :: (v: Value) -> ? str {
     return ret;
 }
 
-#doc """
-    Returns the internal type of the `Value`.
-"""
+/// Returns the internal type of the `Value`.
 Value.type :: (v: Value) -> Type {
     v_u64 := cast(u64, v);
 
@@ -197,7 +189,7 @@ Value.type :: (v: Value) -> Type {
     return .Undefined;
 }
 
-#doc "Calls a method on a `Value`."
+/// Calls a method on a `Value`.
 Value.call :: #match {
     (v: Value, method: str, args: [] any) -> Value {
         transform_args(args, [](__method(v, method, mapped_args)));
@@ -208,7 +200,7 @@ Value.call :: #match {
     }
 }
 
-#doc "Invokes the `Value` as though it is a JavaScript function."
+/// Invokes the `Value` as though it is a JavaScript function.
 Value.invoke :: #match {
     (v: Value, args: ..any) -> Value {
         transform_args(args, [](__call(v, mapped_args)));
@@ -219,7 +211,7 @@ Value.invoke :: #match {
     }
 }
 
-#doc "Removes the `Value` from current `ValuePool`. This means that the `Value` will not be automatically collected, and must be released with `Value.release`."
+/// Removes the `Value` from current `ValuePool`. This means that the `Value` will not be automatically collected, and must be released with `Value.release`.
 Value.leak :: (v: Value) -> Value {
     if __current_pool {
         __current_pool->remove(v);
@@ -228,7 +220,7 @@ Value.leak :: (v: Value) -> Value {
     return v;
 }
 
-#doc "Releases the `Value` from the JavaScript heap. The `Value` should not be used after this method is called."
+/// Releases the `Value` from the JavaScript heap. The `Value` should not be used after this method is called.
 Value.release :: (v: Value) {
     if __current_pool {
         __current_pool->remove(v);
@@ -237,7 +229,7 @@ Value.release :: (v: Value) {
     return __free(v);
 }
 
-#doc "Invokes the JavaScript `delete` operator on the specified property."
+/// Invokes the JavaScript `delete` operator on the specified property.
 Value.delete :: (v: Value, property: str) {
     return __delete(v, property);
 }
@@ -258,24 +250,24 @@ Value.is_nan :: (v: Value) -> bool {
     return cast(u64) v == cast(u64) NaN;
 }
 
-#doc "Returns the evaluation of the `instanceof` operator in JavaScript."
+/// Returns the evaluation of the `instanceof` operator in JavaScript.
 Value.instance_of :: (v: Value, base: Value) -> bool {
     return __instance_of(v, base);
 }
 
-#doc "Invokes the `new` operator on the `Value`, with arguments `args`."
+/// Invokes the `new` operator on the `Value`, with arguments `args`.
 Value.new :: (v: Value, args: ..any) -> Value {
     transform_args(cast([] any) args, [](__new(v, mapped_args)));
 }
 
-#doc "Retrieves the evaluation of `v[prop]` in JavaScript."
+/// Retrieves the evaluation of `v[prop]` in JavaScript.
 Value.get :: (v: Value, prop: str) -> Value {
     r := __dot(v, prop);
     __add_to_pool(r);
     return r;
 }
 
-#doc "Retrieves the evaluation of `v[prop] = value` in JavaScript."
+/// Retrieves the evaluation of `v[prop] = value` in JavaScript.
 Value.set :: #match #locked {
     (v: Value, prop: str, value: Value) {
         __set(v, prop, value);
@@ -298,22 +290,20 @@ Value.set :: #match #locked {
     }
 }
 
-#doc """Special case for `->get("length")`. Because it is required so often, this optimization is quite nice."""
+/// Special case for `->get("length")`. Because it is required so often, this optimization is quite nice.
 Value.length :: (v: Value) -> i32 {
     return __len(v);
 }
 
-#doc "Retrieves the evaluation of `v[i]` in JavaScript."
+/// Retrieves the evaluation of `v[i]` in JavaScript.
 Value.index :: (v: Value, i: i32) -> Value {
     r := __sub(v, i);
     __add_to_pool(r);
     return r;
 }
 
-#doc """
-    JavaScript defines a "falsesy" value as undefined, null, false, 0, and "".
-    All other values are "truthy".
-"""
+/// JavaScript defines a "falsesy" value as undefined, null, false, 0, and "".
+/// All other values are "truthy".
 Value.truthy :: (v: Value) -> bool {
     switch v->type() {
         case .Undefined, .Null do return false;
@@ -324,19 +314,15 @@ Value.truthy :: (v: Value) -> bool {
     }
 }
 
-#doc """
-    Copies data from a Uint8Array in JS to a buffer in Onyx.
-    Returns the number of bytes copied, or -1 if the value was not a Uint8Array.
-"""
+/// Copies data from a Uint8Array in JS to a buffer in Onyx.
+/// Returns the number of bytes copied, or -1 if the value was not a Uint8Array.
 Value.copy_to_onyx :: (v: Value, buf: [] u8) -> i32 {
     return __copy_to_onyx(buf, v);
 }
 
 
-#doc """
-    Copies data into a Uint8Array in JS from a buffer in Onyx.
-    Returns the number of bytes copied, or -1 if the value was not a Uint8Array.
-"""
+/// Copies data into a Uint8Array in JS from a buffer in Onyx.
+/// Returns the number of bytes copied, or -1 if the value was not a Uint8Array.
 Value.copy_to_js :: (v: Value, buf: [] u8) -> i32 {
     return __copy_to_js(v, buf);
 }
@@ -391,10 +377,8 @@ __add_to_pool :: macro (v: Value) {
 }
 
 
-#doc """
-    To aid in managing `Value`s that are created over the life time of the program,
-    `ValuePool` collects all of the `Value`s and allows for releasing them all at once.
-"""
+/// To aid in managing `Value`s that are created over the life time of the program,
+/// `ValuePool` collects all of the `Value`s and allows for releasing them all at once.
 ValuePool :: struct {
     values: [..] Value = make([..] Value, alloc.heap_allocator);
 }
@@ -420,29 +404,27 @@ ValuePool.destroy :: (vp: &ValuePool) {
     delete(&vp.values);
 }
 
-#doc "Gets the current `ValuePool` in use."
+/// Gets the current `ValuePool` in use.
 get_pool :: () => __current_pool;
 
-#doc "Sets the `ValuePool` to use."
+/// Sets the `ValuePool` to use.
 set_pool :: (vp: &ValuePool) {
     __current_pool = vp;
 }
 
-#doc "Creates a new `ValuePool` and uses it. The old `ValuePool` is forgotten."
+/// Creates a new `ValuePool` and uses it. The old `ValuePool` is forgotten.
 setup_default_pool :: () {
     __current_pool = new(ValuePool);
 }
 
-#doc "Releases all objects in the current `ValuePool`."
+/// Releases all objects in the current `ValuePool`.
 release_pooled_objects :: () {
     if __current_pool {
         __current_pool->release_all();
     }
 }
 
-#doc """
-    Helper macro to create a `ValuePool` that is scoped to a block.
-"""
+/// Helper macro to create a `ValuePool` that is scoped to a block.
 temp_pool :: #match {
     macro (body: Code) -> u32 {
         #this_package.temp_pool();

--- a/core/misc/any_utils.onyx
+++ b/core/misc/any_utils.onyx
@@ -28,7 +28,7 @@ any_as :: (a: any, $T: type_expr) -> &T {
     return cast(&T) a.data;
 }
 
-#doc "Dereference a pointer any."
+/// Dereference a pointer any.
 any_dereference :: (v: any) -> any {
     t := get_type_info(v.type);
     if t.kind == .Pointer {
@@ -39,7 +39,7 @@ any_dereference :: (v: any) -> any {
     return v;
 }
 
-#doc "Unwraps an optional any, if the any is an optional. `? T -> T`"
+/// Unwraps an optional any, if the any is an optional. `? T -> T`
 any_unwrap :: (v: any) -> any {
     if union_constructed_from(v.type, Optional) {
         t := v.type->info()->as_union();
@@ -53,7 +53,7 @@ any_unwrap :: (v: any) -> any {
 }
 
 
-#doc "Subscript an array-like any."
+/// Subscript an array-like any.
 any_subscript :: (v: any, index: i32) -> any {
     base_ptr, elem_type, count := any_as_array(v);
     if index >= count || index < 0 {
@@ -66,7 +66,7 @@ any_subscript :: (v: any, index: i32) -> any {
     };
 }
 
-#doc "Select a member from an any."
+/// Select a member from an any.
 any_selector :: (v: any, member_name: str) -> any {
     t := get_type_info(v.type);
     if t.kind == .Struct {
@@ -79,7 +79,7 @@ any_selector :: (v: any, member_name: str) -> any {
     return .{null, void};
 }
 
-#doc "Like `any_selector`, but works with selecting \"foo.bar.joe\"."
+/// Like `any_selector`, but works with selecting \"foo.bar.joe\".
 any_nested_selector :: (v: any, member_name: str) -> any {
     t := get_type_info(v.type);
     if t.kind != .Struct do return .{};
@@ -100,8 +100,6 @@ any_nested_selector :: (v: any, member_name: str) -> any {
     return .{null, void};
 }
 
-#doc """
-"""
 any_member :: #match #locked {
     (v: any, member_type: type_expr, member_offset: u32) -> any {
         return any.{
@@ -118,20 +116,18 @@ any_member :: #match #locked {
     }
 }
 
-#doc """
-    Convert a structure or pointer to a structure to a Map with
-    keys representing the fields of the structure, and values
-    representing the value of each field.
-   
-        T :: struct {
-            x := 123;
-            y := "test";
-        }
-        
-        m := any_to_map(T.{});
-   
-    `m` would have two keys, "x" and "y".
-"""
+/// Convert a structure or pointer to a structure to a Map with
+/// keys representing the fields of the structure, and values
+/// representing the value of each field.
+///
+///     T :: struct {
+///         x := 123;
+///         y := "test";
+///     }
+///     
+///     m := any_to_map(T.{});
+///
+/// `m` would have two keys, "x" and "y".
 any_to_map :: (v: any) -> ? Map(str, any) {
     vals := v;
     if vals.type->info().kind == .Pointer {
@@ -151,7 +147,7 @@ any_to_map :: (v: any) -> ? Map(str, any) {
     return out;
 }
 
-#doc "Creates an iterator out of an array-like any."
+/// Creates an iterator out of an array-like any.
 any_iter :: (arr: any) -> Iterator(any) {
     base_ptr, elem_type, count := any_as_array(arr);
     if count == 0 {

--- a/core/misc/arg_parse.onyx
+++ b/core/misc/arg_parse.onyx
@@ -6,27 +6,25 @@ use core.conv
 use core.string
 use runtime
 
-#doc """
-    This is currently a very basic argument parsing library.
-    The options are given through a structure like so:
-   
-        Options :: struct {
-            @"--option_1"
-            option_1: str;
-        
-            @"--option_2", "-o2"
-            option_2: bool;
-        }
-   
-        main :: (args) => {
-            o: Options;
-            arg_parse.arg_parse(args, &o);
-        }
-   
-    Options that are strings and integers expect an argument after
-    them to specify their value. Options that are bool default to
-    false and are true if one or more of the option values are present.
-""" 
+/// This is currently a very basic argument parsing library.
+/// The options are given through a structure like so:
+///
+///     Options :: struct {
+///         @"--option_1"
+///         option_1: str;
+///     
+///         @"--option_2", "-o2"
+///         option_2: bool;
+///     }
+///     
+///     main :: (args) => {
+///         o: Options;
+///         arg_parse.arg_parse(args, &o);
+///     }
+///
+/// Options that are strings and integers expect an argument after
+/// them to specify their value. Options that are bool default to
+/// false and are true if one or more of the option values are present.
 arg_parse :: (c_args: [] cstr, output: any) -> bool {
     arg_iter := iter.as_iter(c_args) |>
                 iter.map(string.from_cstr);

--- a/core/onyx/cbindgen.onyx
+++ b/core/onyx/cbindgen.onyx
@@ -41,7 +41,7 @@ package cbindgen
 
 use runtime
 
-#doc "Deprecated. Use `link_name`."
+/// Deprecated. Use `link_name`.
 customize :: struct {
     symbol_name: str;
 }

--- a/core/os/path.onyx
+++ b/core/os/path.onyx
@@ -12,15 +12,13 @@ use core.conv
     PATH_SEP :: '/'
 }
 
-#doc """
-    Removes:
-    - Stray '.' in the path
-    - Stray '..'
-    - Repeated '/'
-    - Trailing '/'
-
-    Modifies the string in place, as the length will never be longer.
-"""
+/// Removes:
+/// - Stray '.' in the path
+/// - Stray '..'
+/// - Repeated '/'
+/// - Trailing '/'
+///
+/// Modifies the string in place, as the length will never be longer.
 path_clean :: (path: str, allocator := Path_Allocator) -> str {
     if path == "" do return string.copy(".", Path_Allocator);
 
@@ -73,11 +71,9 @@ path_clean :: (path: str, allocator := Path_Allocator) -> str {
     return out;
 }
 
-#doc """
-    Concatenates path elements, and returns cleaned output.
-
-    This uses the temporary allocator, so a copy may be needed.
-"""
+/// Concatenates path elements, and returns cleaned output.
+///
+/// This uses the temporary allocator, so a copy may be needed.
 path_join :: (path: ..str) -> str {
     out := make(dyn_str, allocator=context.temp_allocator);
     
@@ -88,23 +84,19 @@ path_join :: (path: ..str) -> str {
     return path_clean(out);
 }
 
-#doc """
-    Returns everything but the last element in the path.
-
-    This is then cleaned and copied into the temporary allocator.
-"""
+/// Returns everything but the last element in the path.
+///
+/// This is then cleaned and copied into the temporary allocator.
 path_directory :: (path: str) -> str {
     dir, _ := path_split(path);
     return path_clean(dir);
 }
 
-#doc """
-    Returns the extension of the file on the end of the path, if present.
-
-        path_extension("foo.txt") -> "txt"
-        path_extension("foo/bar") -> ""
-        path_extension("foo/bar.txt") -> "txt"
-"""
+/// Returns the extension of the file on the end of the path, if present.
+///
+///     path_extension("foo.txt") -> "txt"
+///     path_extension("foo/bar") -> ""
+///     path_extension("foo/bar.txt") -> "txt"
 path_extension :: (path: str) -> str {
     for i in range.{ path.length - 1, 0, -1 } {
         if path[i] == PATH_SEP do break;
@@ -113,12 +105,10 @@ path_extension :: (path: str) -> str {
     return "";
 }
 
-#doc """
-    Returns the last element of the path, sans its extension.
-
-        path_basename("foo.txt") -> "foo"
-        path_basename("test/bar.txt") -> "bar"
-"""
+/// Returns the last element of the path, sans its extension.
+///
+///     path_basename("foo.txt") -> "foo"
+///     path_basename("test/bar.txt") -> "bar"
 path_basename :: (path: str) -> str {
     if path == "" do return ".";
 
@@ -127,9 +117,7 @@ path_basename :: (path: str) -> str {
     return path[start + 1 .. end];
 }
 
-#doc """
-    Splits the last path element off.
-"""
+/// Splits the last path element off.
 path_split :: (path: str) -> (str, str) {
     index := string.last_index_of(path, PATH_SEP);
     return path[0 .. index], path[index+1 .. path.length];

--- a/core/os/process.onyx
+++ b/core/os/process.onyx
@@ -19,17 +19,13 @@ use runtime.platform {
     ProcessData
 }
 
-#doc """
-    Represents a spawned OS process.
-"""
+/// Represents a spawned OS process.
 Process :: struct {
     use stream: io.Stream;
     process_handle: ProcessData;
 }
 
-#doc """
-    Represents options for process creation.
-"""
+/// Represents options for process creation.
 ProcessSpawnOpts :: struct {
     capture_io: bool;
     non_blocking_io: bool; 
@@ -38,11 +34,9 @@ ProcessSpawnOpts :: struct {
     environment: [] Pair(str, str);
 }
 
-#doc """
-    Spawns a new OS process. This operation is always assumed to succeed.
-    To determine if the operation failed, use `process_wait` and look for the
-    `FailedToRun` state.
-"""
+/// Spawns a new OS process. This operation is always assumed to succeed.
+/// To determine if the operation failed, use `process_wait` and look for the
+/// `FailedToRun` state.
 process_spawn :: #match #local -> Process {}
 
 #overload
@@ -80,17 +74,17 @@ process_spawn :: (path: str, args: [] str, opts: &ProcessSpawnOpts) -> Process {
     };
 }
 
-#doc "Force kills a subprocess."
+/// Force kills a subprocess.
 process_kill :: (use p: &Process) -> bool {
     return __process_kill(process_handle);
 }
 
-#doc "Waits for a process to exit."
+/// Waits for a process to exit.
 process_wait :: (use p: &Process) => {
     return __process_wait(process_handle);
 }
 
-#doc "Frees internal resources used by a process. Should be called after process_kill or process_wait."
+/// Frees internal resources used by a process. Should be called after process_kill or process_wait.
 process_destroy :: (use p: &Process) => {
     __process_destroy(process_handle);
 }
@@ -131,11 +125,9 @@ process_destroy :: (use p: &Process) => {
     }
 }
 
-#doc """
-    Represents exit states of a process.
-
-    This is not the best format for this data, as it is impossible to get the exit status.
-"""
+/// Represents exit states of a process.
+///
+/// This is not the best format for this data, as it is impossible to get the exit status.
 ProcessResult :: enum {
     Success     :: 0x00;
     FailedToRun :: 0x01;
@@ -143,9 +135,7 @@ ProcessResult :: enum {
     InternalErr :: 0x03;
 }
 
-#doc """
-    Represents the exit state and output of a process.
-"""
+/// Represents the exit state and output of a process.
 ProcessResultOutput :: struct {
     result: ProcessResult;
     output: str;
@@ -156,9 +146,7 @@ ProcessResultOutput :: struct {
 // Builder pattern for processes
 //
 
-#doc """
-    Stores configuration used by the builder pattern for processes.
-"""
+/// Stores configuration used by the builder pattern for processes.
 Command :: struct {
     _path: str;
     _args: [..] str;
@@ -169,43 +157,41 @@ Command :: struct {
     _opts: ProcessSpawnOpts;
 }
 
-#doc """
-    Produces a new `Command` for the process builder.
-
-        os.command()
-            ->path("executable_path")
-            ->args(.["argument", "list"])
-            ->run();
-"""
+/// Produces a new `Command` for the process builder.
+///
+///     os.command()
+///         ->path("executable_path")
+///         ->args(.["argument", "list"])
+///         ->run();
 command :: () -> &Command {
     return new(Command);
 }
 
-#doc "Sets the path of the command."
+/// Sets the path of the command.
 Command.path :: (cmd: &Command, path: str) -> &Command {
     cmd._path = path;
     return cmd;
 }
 
-#doc "Appends arguments to the argument array of the command."
+/// Appends arguments to the argument array of the command.
 Command.args :: (cmd: &Command, args: [] str) -> &Command {
     array.concat(&cmd._args, args);
     return cmd;
 }
 
-#doc "Sets an environment variable."
+/// Sets an environment variable.
 Command.env :: (cmd: &Command, key, value: str) -> &Command {
     cmd._env << .{ key, value };
     return cmd;
 }
 
-#doc "Sets the working directory of the command."
+/// Sets the working directory of the command.
 Command.dir :: (cmd: &Command, dir: str) -> &Command {
     cmd._dir = dir;
     return cmd;
 }
 
-#doc "Runs the command, wait until it completes, and capture output."
+/// Runs the command, wait until it completes, and capture output.
 Command.output :: (cmd: &Command) -> Result(str, ProcessResultOutput) {
     if !cmd._process {
         cmd._opts.capture_io = true;
@@ -228,19 +214,19 @@ Command.output :: (cmd: &Command) -> Result(str, ProcessResultOutput) {
     return .{ Ok = output };
 }
 
-#doc "Runs the command and waits until it completes."
+/// Runs the command and waits until it completes.
 Command.run :: (cmd: &Command) -> ProcessResult {
     cmd->start();
     return cmd->wait();
 }
 
-#doc "Starts the command with the mapped I/O."
+/// Starts the command with the mapped I/O.
 Command.start_with_output :: (cmd: &Command) -> &Command {
     cmd._opts.capture_io = true;
     return cmd->start();
 }
 
-#doc "Starts the command."
+/// Starts the command.
 Command.start :: (cmd: &Command) -> &Command {
     cmd._opts.environment = cmd._env;
     cmd._opts.dir = cmd._dir;
@@ -249,7 +235,7 @@ Command.start :: (cmd: &Command) -> &Command {
     return cmd;
 }
 
-#doc "Wait for the command to complete."
+/// Wait for the command to complete.
 Command.wait :: (cmd: &Command) -> ProcessResult {
     if !cmd._process do return .Error;
 
@@ -260,7 +246,7 @@ Command.wait :: (cmd: &Command) -> ProcessResult {
     return res;
 }
 
-#doc "Destroys all internal information of a command. Automatically called by `Command.wait`."
+/// Destroys all internal information of a command. Automatically called by `Command.wait`.
 Command.destroy :: (cmd: &Command) {
     delete(&cmd._args);
     delete(&cmd._env);

--- a/core/random/random.onyx
+++ b/core/random/random.onyx
@@ -3,53 +3,49 @@ package core.random
 use core
 use runtime
 
-#doc "The state of a random number generator."
+/// The state of a random number generator.
 Random :: struct {
     seed: i64;
 }
 
-#doc """
-    Creates a new random number generator.
-
-    An initial seed can be passed in, otherwise the current UNIX time is used.
-"""
+/// Creates a new random number generator.
+///
+/// An initial seed can be passed in, otherwise the current UNIX time is used.
 Random.make :: (seed: i64 = (#unquote __initial_value)) -> Random {
     return .{ seed };
 }
 
-#doc "Sets the seed of the random number generator."
+/// Sets the seed of the random number generator.
 Random.set_seed :: #match {
     (self: &Random, s: u32) { self.seed = ~~s; },
     (self: &Random, s: u64) { self.seed =   s; },
 }
 
-#doc "Generates a random 32-bit integer."
+/// Generates a random 32-bit integer.
 Random.int :: (self: &Random) -> u32 {
     s := self.seed * RANDOM_MULTIPLIER + RANDOM_INCREMENT;
     defer self.seed = s;
     return cast(u32) ((s >> 16) & ~~0xffffffff);
 }
 
-#doc "Generates a random 32-bit integer between `lo` and `hi`, inclusive."
+/// Generates a random 32-bit integer between `lo` and `hi`, inclusive.
 Random.between :: (self: &Random, lo: i32, hi: i32) -> i32 {
     return self->int() % (hi + 1 - lo) + lo;
 }
 
-#doc "Generates a random floating point number between `lo` and `hi`."
+/// Generates a random floating point number between `lo` and `hi`.
 Random.float :: (self: &Random, lo := 0.0f, hi := 1.0f) -> f32 {
     return (cast(f32) (self->int() % (1 << 23)) / cast(f32) (1 << 23)) * (hi - lo) + lo;
 }
 
-#doc "Returns a random element from a slice."
+/// Returns a random element from a slice.
 Random.choice :: (self: &Random, a: [] $T) -> T {
     return a[self->between(0, a.count - 1)];
 }
 
-#doc """
-    Returns a random byte-array of length `bytes_long`.
-
-    If `alpha_numeric` is true, then the string will only consist of alpha-numeric characters.
-"""
+/// Returns a random byte-array of length `bytes_long`.
+///
+/// If `alpha_numeric` is true, then the string will only consist of alpha-numeric characters.
 Random.string :: (self: &Random, bytes_long: u32, alpha_numeric := false, allocator := context.allocator) -> str {
     use core.memory
 
@@ -75,33 +71,31 @@ Random.string :: (self: &Random, bytes_long: u32, alpha_numeric := false, alloca
 // The global random state.
 global_random := Random.{ 8675309 };
 
-#doc "Sets the seed for the global random number generator."
+/// Sets the seed for the global random number generator.
 set_seed :: #match {
     (s: u32) { global_random->set_seed(~~s); },
     (s: u64) { global_random->set_seed(s); },
 }
 
-#doc "Generates a random integer."
+/// Generates a random integer.
 int :: () =>
     global_random->int();
 
-#doc "Generates a random integer, between `lo` and `hi` inclusively."
+/// Generates a random integer, between `lo` and `hi` inclusively.
 between :: (lo: i32, hi: i32) =>
     global_random->between(lo, hi);
 
-#doc "Generates a random floating point number."
+/// Generates a random floating point number.
 float :: (lo := 0.0f, hi := 1.0f) =>
     global_random->float(lo, hi);
 
-#doc "Chooses a random element out of a slice."
+/// Chooses a random element out of a slice.
 choice :: (a: [] $T) =>
     global_random->choice(a);
 
-#doc """
-    Returns a random byte-array of length `bytes_long`.
-
-    If `alpha_numeric` is true, then the string will only consist of alpha-numeric characters.
-"""
+/// Returns a random byte-array of length `bytes_long`.
+///
+/// If `alpha_numeric` is true, then the string will only consist of alpha-numeric characters.
 string :: (bytes_long: u32, alpha_numeric := false, allocator := context.allocator) =>
     global_random->string(bytes_long, alpha_numeric, allocator);
 

--- a/core/string/string.onyx
+++ b/core/string/string.onyx
@@ -3,7 +3,7 @@ package core.string
 use core {package, *}
 
 
-#doc "Generic procedure for turning something into a string."
+/// Generic procedure for turning something into a string.
 as_str :: #match -> str {}
 
 #local HasAsStrMethod :: interface (T: type_expr) {
@@ -54,13 +54,11 @@ from_cstr :: (s: cstr) -> str {
     return .{ data = s, count = length(s) };
 }
 
-#doc """
-    Converts a `str` into a `cstr` by copying the memory of the string to the stack,
-    with an additional byte at the end that is set to 0, to correctly for a C-string.
-
-    This only needs to be done when the string does not contain a `\0` byte on the end,
-    which is most of the time. If you know that the string has a `\0` byte, simply use `s.data`.
-"""
+/// Converts a `str` into a `cstr` by copying the memory of the string to the stack,
+/// with an additional byte at the end that is set to 0, to correctly for a C-string.
+///
+/// This only needs to be done when the string does not contain a `\0` byte on the end,
+/// which is most of the time. If you know that the string has a `\0` byte, simply use `s.data`.
 to_cstr_on_stack :: macro (s_: str) -> cstr {
     use core.alloc
     use core.memory

--- a/core/sync/barrier.onyx
+++ b/core/sync/barrier.onyx
@@ -13,10 +13,8 @@ package core.sync
 // continue processing.
 //
 
-#doc """
-    Represents a generational barrier, so the same barrier
-    can be used safely multiple times.
-"""
+/// Represents a generational barrier, so the same barrier
+/// can be used safely multiple times.
 Barrier :: struct {
     mutex : Mutex;
     cond  : Condition_Variable;
@@ -27,7 +25,7 @@ Barrier :: struct {
 }
 
 
-#doc "Initializes a new generational barrier with `thread_count` threads."
+/// Initializes a new generational barrier with `thread_count` threads.
 barrier_init :: (b: &Barrier, thread_count: i32) {
     mutex_init(&b.mutex);
     condition_init(&b.cond);
@@ -38,16 +36,14 @@ barrier_init :: (b: &Barrier, thread_count: i32) {
 }
 
 
-#doc "Destroys a generational barrier."
+/// Destroys a generational barrier.
 barrier_destroy :: (b: &Barrier) {
     mutex_destroy(&b.mutex);
     condition_destroy(&b.cond);
 }
 
-#doc """
-    Signals that a thread has reached the barrier.
-    The last thread to reach the barrier will wake up all other threads.
-"""
+/// Signals that a thread has reached the barrier.
+/// The last thread to reach the barrier will wake up all other threads.
 barrier_wait :: (b: &Barrier) {
     mutex_lock(&b.mutex);
     defer mutex_unlock(&b.mutex);

--- a/core/sync/condition_variable.onyx
+++ b/core/sync/condition_variable.onyx
@@ -2,22 +2,20 @@ package core.sync
 
 // TODO: Free the semaphores after they are used.
 
-#doc """
-    A condition variable is used to implement a queue of threads
-    waiting for a condition to be true. Each thread joins the queue
-    using `condition_wait`. Then, another thread can signal that
-    the condition has changed and can "wake up" the first thread in
-    the queue using `condition_signal`. Alternatively, all threads
-    can be woken up using `condition_broadcast`.
-   
-    Condition variables are generally used to prevent spin checking
-    a condition and waiting for it to change. Instead, the thread
-    joins a wait-queue, and leave it up to another thread to wake
-    it up to continue processing. However sadly, in WebAssembly this
-    is not possible because with the atomic_wait and atomic_notify
-    instructions, which currently are not supported by any runtime
-    outside of the browser.
-"""
+/// A condition variable is used to implement a queue of threads
+/// waiting for a condition to be true. Each thread joins the queue
+/// using `condition_wait`. Then, another thread can signal that
+/// the condition has changed and can "wake up" the first thread in
+/// the queue using `condition_signal`. Alternatively, all threads
+/// can be woken up using `condition_broadcast`.
+///
+/// Condition variables are generally used to prevent spin checking
+/// a condition and waiting for it to change. Instead, the thread
+/// joins a wait-queue, and leave it up to another thread to wake
+/// it up to continue processing. However sadly, in WebAssembly this
+/// is not possible because with the atomic_wait and atomic_notify
+/// instructions, which currently are not supported by any runtime
+/// outside of the browser.
 Condition_Variable :: struct {
     Node :: struct {
         semaphore : Semaphore;
@@ -28,24 +26,22 @@ Condition_Variable :: struct {
     queue: &Node;
 }
 
-#doc "Initializes a new condition variable."
+/// Initializes a new condition variable.
 condition_init :: (c: &Condition_Variable) {
     mutex_init(&c.mutex);
     c.queue = null;
 }
 
-#doc "Destroys a condition variable."
+/// Destroys a condition variable.
 condition_destroy :: (c: &Condition_Variable) {
     if c.queue != null do condition_broadcast(c);
 
     mutex_destroy(&c.mutex);
 }
 
-#doc """
-    Enters the thread in the wait-queue of the condition variable.
-    If `m` is not null, the mutex will first be released before
-    entering the queue, and then relocked before returning.
-"""
+/// Enters the thread in the wait-queue of the condition variable.
+/// If `m` is not null, the mutex will first be released before
+/// entering the queue, and then relocked before returning.
 condition_wait :: (c: &Condition_Variable, m: &Mutex) {
     node: Condition_Variable.Node;
 
@@ -61,7 +57,7 @@ condition_wait :: (c: &Condition_Variable, m: &Mutex) {
 }
 
 
-#doc "Wakes up one thread from the wait-queue."
+/// Wakes up one thread from the wait-queue.
 condition_signal :: (c: &Condition_Variable) {
     scoped_mutex(&c.mutex);
 
@@ -72,7 +68,7 @@ condition_signal :: (c: &Condition_Variable) {
 }
 
 
-#doc "Wakes up all threads from the wait-queue."
+/// Wakes up all threads from the wait-queue.
 condition_broadcast :: (c: &Condition_Variable) {
     scoped_mutex(&c.mutex);
 

--- a/core/sync/mutex.onyx
+++ b/core/sync/mutex.onyx
@@ -5,51 +5,47 @@ use core
 use core.intrinsics.atomics {*}
 use core.thread { Thread_ID }
 
-#doc """
-    A mutex represents a resource that can only be held by one
-    thread at a time. It is used to create sections of code that
-    only one thread can be in at a time.
-   
-    Mutexes in WebAssembly are very cheap, because they simply
-    use the atomic_cmpxchg intrinsic to operate. This only uses
-    memory, so no real resource allocation is necessary.
-   
-    `lock` has two states: 0, and 1.
-    0 means unlocked, 1 means locked
-   
-    To lock it:
-        Try to store 1 if the value was already 0.
-        Otherwise, if it was already 1, wait until it goes to 0.
-   
-    To unlock it:
-        Atomically set it to 0.
-        Notify at most 1 other thread about this change.
-"""
+/// A mutex represents a resource that can only be held by one
+/// thread at a time. It is used to create sections of code that
+/// only one thread can be in at a time.
+///
+/// Mutexes in WebAssembly are very cheap, because they simply
+/// use the atomic_cmpxchg intrinsic to operate. This only uses
+/// memory, so no real resource allocation is necessary.
+///
+/// `lock` has two states: 0, and 1.
+/// 0 means unlocked, 1 means locked
+///
+/// To lock it:
+///     Try to store 1 if the value was already 0.
+///     Otherwise, if it was already 1, wait until it goes to 0.
+///
+/// To unlock it:
+///     Atomically set it to 0.
+///     Notify at most 1 other thread about this change.
 Mutex :: struct {
     lock  : i32;
     owner : Thread_ID;
 }
 
 
-#doc "Initializes a new mutex."
+/// Initializes a new mutex.
 mutex_init :: (m: &Mutex) {
     m.lock = 0;
     m.owner = -1;
 }
 
 
-#doc "Destroys a mutex."
+/// Destroys a mutex.
 mutex_destroy :: (m: &Mutex) {
     m.lock = -1;
     m.owner = -1;
 }
 
-#doc """
-    Locks a mutex. If the mutex is currently held by another thread,
-    this function enters a spin loop until the mutex is unlocked.
-    In a JavaScript based implementation, the __atomic_wait intrinsic
-    is used to avoid having to spin loop.
-"""
+/// Locks a mutex. If the mutex is currently held by another thread,
+/// this function enters a spin loop until the mutex is unlocked.
+/// In a JavaScript based implementation, the __atomic_wait intrinsic
+/// is used to avoid having to spin loop.
 mutex_lock :: (m: &Mutex) {
     while __atomic_cmpxchg(&m.lock, 0, 1) == 1 {
         if m.owner == context.thread_id do return;
@@ -64,11 +60,9 @@ mutex_lock :: (m: &Mutex) {
     m.owner = context.thread_id;
 }
 
-#doc """
-    Unlocks a mutex, if the calling thread currently holds the mutex.
-    In a JavaScript based implementation, the __atomic_notify intrinsic
-    is used to wake up one waiting thread.
-"""
+/// Unlocks a mutex, if the calling thread currently holds the mutex.
+/// In a JavaScript based implementation, the __atomic_notify intrinsic
+/// is used to wake up one waiting thread.
 mutex_unlock :: (m: &Mutex) {
     if m.owner != context.thread_id do return;
     
@@ -80,17 +74,15 @@ mutex_unlock :: (m: &Mutex) {
     }
 }
 
-#doc """
-    Helpful macro for making a particular block be protected by a macro.
-   
-        m: sync.Mutx;
-        sync.mutex_init(&m);
-        
-        {
-           sync.scoped_mutex(&m);
-           // Everything here is done by one thread at a time.
-        }
-"""
+/// Helpful macro for making a particular block be protected by a macro.
+///
+///     m: sync.Mutx;
+///     sync.mutex_init(&m);
+///     
+///     {
+///        sync.scoped_mutex(&m);
+///        // Everything here is done by one thread at a time.
+///     }
 scoped_mutex :: macro (m: &Mutex) {
     ml :: mutex_lock
     mu :: mutex_unlock
@@ -99,17 +91,15 @@ scoped_mutex :: macro (m: &Mutex) {
     defer mu(m);
 }
 
-#doc """
-    Abstracts the pattern decribed in scoped_mutex by automatically
-    calling scoped_mutex in the block of code given.
-   
-        m: sync.Mutx;
-        sync.mutex_init(&m);
-        
-        sync.critical_section(&m) {
-           // Everything here is done by one thread at a time.
-        }
-"""
+/// Abstracts the pattern decribed in scoped_mutex by automatically
+/// calling scoped_mutex in the block of code given.
+///
+///     m: sync.Mutx;
+///     sync.mutex_init(&m);
+///     
+///     sync.critical_section(&m) {
+///        // Everything here is done by one thread at a time.
+///     }
 critical_section :: macro (m: &Mutex, body: Code) -> i32 {
     scoped_mutex :: scoped_mutex;
     scoped_mutex(m);

--- a/core/sync/mutex_guard.onyx
+++ b/core/sync/mutex_guard.onyx
@@ -1,14 +1,12 @@
 package core.sync
 
-#doc """
-    Represents a "guarded" value, i.e. one that is protected by a mutex.
-
-    The only way to access the value inside is by using the `with` method and
-    passing in a code block that accepts a pointer to the value. This way,
-    there is no way to access the value without locking a mutex. (Unless of
-    course, you store the pointer somewhere else, but then you are just being
-    a bad citizen of the programming language ;) ).
-"""
+/// Represents a "guarded" value, i.e. one that is protected by a mutex.
+///
+/// The only way to access the value inside is by using the `with` method and
+/// passing in a code block that accepts a pointer to the value. This way,
+/// there is no way to access the value without locking a mutex. (Unless of
+/// course, you store the pointer somewhere else, but then you are just being
+/// a bad citizen of the programming language ;) ).
 MutexGuard :: struct (T: type_expr) {
     _: [(sizeof T) + (sizeof Mutex)] u8;
 }

--- a/core/sync/once.onyx
+++ b/core/sync/once.onyx
@@ -5,7 +5,7 @@ package core.sync
 // function only once. It is simply a flag with a mutex.
 //
 
-#doc "Represents something will only happen once."
+/// Represents something will only happen once.
 Once :: struct {
     done: bool;
     mutex: Mutex;
@@ -13,7 +13,7 @@ Once :: struct {
 
 Once.exec :: #match #local {}
 
-#doc "Run a function with no arguments once."
+/// Run a function with no arguments once.
 #overload
 Once.exec :: (o: &Once, f: () -> $R) {
     scoped_mutex(&o.mutex);
@@ -23,7 +23,7 @@ Once.exec :: (o: &Once, f: () -> $R) {
     f();
 }
 
-#doc "Run a function with one argument once."
+/// Run a function with one argument once.
 #overload
 Once.exec :: (o: &Once, ctx: $Ctx, f: (Ctx) -> $R) {
     scoped_mutex(&o.mutex);

--- a/core/sync/semaphore.onyx
+++ b/core/sync/semaphore.onyx
@@ -3,29 +3,27 @@ package core.sync
 use runtime
 use core
 
-#doc """
-    A semaphore represents a counter that can only be incremented
-    and decremented by one thread at a time. "Waiting" on a semaphore
-    means decrementing the counter by 1 if it is greater than 0, otherwise
-    waiting until the counter is incremented. "Posting" on a semaphore
-    means incrementing the counter by a certain value, in turn releasing
-    other threads that might have been waiting for the value to change.
-   
-    Semaphores are generally used for controlling access to shared
-    resources. For a contrived example, say only 4 threads can use
-    a given network connection at a time. A semaphore would be created
-    with a value of 4. When a thread wants to use the network connection,
-    it would use `semaphore_wait` to obtain the resource, or wait if
-    the network is currently available. When it is done using the
-    network, it would call `semaphore_post` to release the resource,
-    allowing another thread to use it.
-"""
+/// A semaphore represents a counter that can only be incremented
+/// and decremented by one thread at a time. "Waiting" on a semaphore
+/// means decrementing the counter by 1 if it is greater than 0, otherwise
+/// waiting until the counter is incremented. "Posting" on a semaphore
+/// means incrementing the counter by a certain value, in turn releasing
+/// other threads that might have been waiting for the value to change.
+///
+/// Semaphores are generally used for controlling access to shared
+/// resources. For a contrived example, say only 4 threads can use
+/// a given network connection at a time. A semaphore would be created
+/// with a value of 4. When a thread wants to use the network connection,
+/// it would use `semaphore_wait` to obtain the resource, or wait if
+/// the network is currently available. When it is done using the
+/// network, it would call `semaphore_post` to release the resource,
+/// allowing another thread to use it.
 Semaphore :: struct {
     mutex   : Mutex;
     counter : i32;
 }
 
-#doc "Initializes a semaphore with the specified value."
+/// Initializes a semaphore with the specified value.
 semaphore_init :: (s: &Semaphore, value: i32) {
     s.counter = value;
 
@@ -33,13 +31,13 @@ semaphore_init :: (s: &Semaphore, value: i32) {
 }
 
 
-#doc "Destroys a semaphore."
+/// Destroys a semaphore.
 semaphore_destroy :: (s: &Semaphore) {
     mutex_destroy(&s.mutex);
 }
 
 
-#doc "Increment the counter in a semaphore by `count`."
+/// Increment the counter in a semaphore by `count`.
 semaphore_post :: (s: &Semaphore, count := 1) {
     if count == 0 do return;
     
@@ -54,7 +52,7 @@ semaphore_post :: (s: &Semaphore, count := 1) {
     }
 }
 
-#doc "Waits until the thread is able to decrement one from the semaphore."
+/// Waits until the thread is able to decrement one from the semaphore.
 semaphore_wait :: (s: &Semaphore) {
     while true {
         mutex_lock(&s.mutex);

--- a/core/test/testing.onyx
+++ b/core/test/testing.onyx
@@ -8,27 +8,25 @@ use runtime
 
 use core {printf}
 
-#doc """
-    Test tag. Use this to mark a function as a test.
-
-    You can either use just the type name:
-
-        @core.test.test
-        (t: &core.test.T) {
-        }
-
-    Or you can specify a name using the full struct literal:
-
-        @core.test.test.{"Important test name"}
-        (t: &core.test.T) {
-        }
-"""
+/// Test tag. Use this to mark a function as a test.
+///
+/// You can either use just the type name:
+///
+///     @core.test.test
+///     (t: &core.test.T) {
+///     }
+///
+/// Or you can specify a name using the full struct literal:
+///
+///     @core.test.test.{"Important test name"}
+///     (t: &core.test.T) {
+///     }
 test :: struct {
     name: str;
 }
 
 
-#doc "Testing context"
+/// Testing context
 T :: struct {
     current_test_case: &Test_Case;
 }
@@ -45,10 +43,8 @@ T.assert :: (t: &T, cond: bool, name := "", site := #callsite) {
 
 
 
-#doc """
-    Runs all test cases in the provide packages.
-    If no packages are provided, ALL package tests are run.
-"""
+/// Runs all test cases in the provide packages.
+/// If no packages are provided, ALL package tests are run.
 run_tests :: (packages: [] package_id = .[], log := true) -> bool {
     ctx: T;
 

--- a/core/threads/thread.onyx
+++ b/core/threads/thread.onyx
@@ -11,25 +11,21 @@ use core.intrinsics.atomics {*}
 }
 
 
-#doc "An id of a thread."
+/// An id of a thread.
 Thread_ID :: #type i32
 
-#doc """
-    Represents a thread. Currently, this is very simple; just the id
-    of the thread and whether or not it is alive.
-"""
+/// Represents a thread. Currently, this is very simple; just the id
+/// of the thread and whether or not it is alive.
 Thread :: struct {
     id    : Thread_ID;
     alive : bool;
 }
 
-#doc """
-    Spawns a new thread using the runtime.__spawn_thread function.
-    The primary job of this function is to create the thread-local
-    storage and stack for the new thread, and pass those on.
-    Currently the stack size is not controllable, but that could
-    be remedied.
-"""
+/// Spawns a new thread using the runtime.__spawn_thread function.
+/// The primary job of this function is to create the thread-local
+/// storage and stack for the new thread, and pass those on.
+/// Currently the stack size is not controllable, but that could
+/// be remedied.
 spawn :: (t: &Thread, data: &$T, func: (&T) -> void) {
     sync.scoped_mutex(&thread_mutex);
 
@@ -47,11 +43,9 @@ spawn :: (t: &Thread, data: &$T, func: (&T) -> void) {
     runtime.platform.__spawn_thread(t.id, tls_base, stack_base, func, data);
 }
 
-#doc """
-    Waits for a thread to finish before returning.
-    If the thread was not alive in the first place,
-    immediately return.
-"""
+/// Waits for a thread to finish before returning.
+/// If the thread was not alive in the first place,
+/// immediately return.
 join :: (t: &Thread) {
     while t.alive {
         #if runtime.platform.Supports_Futexes {
@@ -63,10 +57,8 @@ join :: (t: &Thread) {
     }
 }
 
-#doc """
-    Forcefully kill a thread using runtime.__kill_thread.
-    Does nothing if the thread was not alive.
-"""
+/// Forcefully kill a thread using runtime.__kill_thread.
+/// Does nothing if the thread was not alive.
 kill :: (t: &Thread) -> i32 {
     if !t.alive do return -1;
 
@@ -76,18 +68,14 @@ kill :: (t: &Thread) -> i32 {
     return 1;
 }
 
-#doc """
-    Special procedure that should only be called once globally
-    that initialize the map of thread ids to thread data.
-"""
+/// Special procedure that should only be called once globally
+/// that initialize the map of thread ids to thread data.
 __initialize :: () {
     thread_map->init();
 }
 
-#doc """
-    Special procedure that is called when a thread exits,
-    or by kill() above.
-"""
+/// Special procedure that is called when a thread exits,
+/// or by kill() above.
 __exited :: (id: i32) {
     sync.scoped_mutex(&thread_mutex);
 

--- a/core/time/time.onyx
+++ b/core/time/time.onyx
@@ -6,11 +6,9 @@ use core.string
 use core.conv
 use runtime
 
-#doc """
-    Represents a timestamp broken down by month, day, year, hour, minute, and seconds.
-
-    *This structure does not represent or store timezone information.*
-"""
+/// Represents a timestamp broken down by month, day, year, hour, minute, and seconds.
+///
+/// *This structure does not represent or store timezone information.*
 Timestamp :: struct #size (sizeof u32 * 12) {
     sec:   i32;
     min:   i32;
@@ -23,7 +21,7 @@ Timestamp :: struct #size (sizeof u32 * 12) {
     isdst: i32;
 }
 
-#doc "Converts a Date into a Timestamp."
+/// Converts a Date into a Timestamp.
 Timestamp.from_date :: (d: Date) -> Timestamp {
     return .{
         year = d.year - 1900,
@@ -32,14 +30,14 @@ Timestamp.from_date :: (d: Date) -> Timestamp {
     };
 }
 
-#doc "Converts the month, day and year fields into a `Date`."
+/// Converts the month, day and year fields into a `Date`.
 Timestamp.as_date :: (t: Timestamp) -> Date {
     return Date.make(t.year + 1900, t.mon + 1, t.mday);
 }
 
 Timestamp.to_epoch :: to_epoch
 
-#doc "Formats a timestamp into a string."
+/// Formats a timestamp into a string.
 Timestamp.format :: (t: Timestamp, format := "%Y-%m-%d %H:%M:%S") -> str {
     t_ := t;
     return strftime(format, &t_);
@@ -58,9 +56,7 @@ Timestamp.format :: (t: Timestamp, format := "%Y-%m-%d %H:%M:%S") -> str {
     return strptime(data, "%Y-%m-%d %H:%M:%S", time);
 }
 
-#doc """
-    Returns the current system time at UTC-0.
-"""
+/// Returns the current system time at UTC-0.
 now :: () -> Timestamp {
     current_time: i64;
     #if runtime.platform.Supports_Time {
@@ -77,11 +73,9 @@ now :: () -> Timestamp {
 
 to_epoch :: tm_to_time
 
-#doc """
-    Converts UNIX epoch time to a timestamp, relative to the current timezone.
-
-    *Note, this function is currently not implemented correctly as there is no reliable way to get the current system timezone. It is currently equivalent to `gmtime`*
-"""
+/// Converts UNIX epoch time to a timestamp, relative to the current timezone.
+///
+/// *Note, this function is currently not implemented correctly as there is no reliable way to get the current system timezone. It is currently equivalent to `gmtime`*
 localtime :: #match #local {}
 
 #overload
@@ -95,11 +89,9 @@ localtime :: (seconds: u64) -> Timestamp {
 }
 
 
-#doc """
-    Converts UNIX epoch time to a timestamp, relative to the Greenich mean time.
-
-    *Note, this function is currently not implemented correctly as there is no reliable way to get the current system timezone. It is currently equivalent to `gmtime`*
-"""
+/// Converts UNIX epoch time to a timestamp, relative to the Greenich mean time.
+//
+/// *Note, this function is currently not implemented correctly as there is no reliable way to get the current system timezone. It is currently equivalent to `gmtime`*
 gmtime :: #match #local {}
 
 #overload
@@ -114,51 +106,49 @@ gmtime :: (seconds: u64) -> Timestamp {
 
 strftime :: #match #local {}
 
-#doc """
-    Formats a timestamp into a string, using the format specified.
-
-    The follow format specifiers are supported:
-
-    **%A** Day of the week (Sunday, Monday, ...)
-
-    **%a** Short day of the week (Sun, Mon, ...)
-
-    **%B** Month (January, February, ...)
-
-    **%b %h** Short month (Jan, Feb, ...)
-
-    **%d %e** Day of the month (01, ..., 31)
-
-    **%D** Full day (08/31/2023)
-
-    **%H** Hour (00, ..., 23)
-
-    **%I** 12-hour Hour (12, 01, ..., 11, 12)
-
-    **%j** Day of the year (0, ..., 364)
-
-    **%m** Month number (01, 02, ... 12)
-
-    **%M** Minute (00, ..., 59)
-
-    **%p** AM/PM signifier
-
-    **%r** 12-hour time of day (12:15:39 pm)
-
-    **%R** 24-hour time of day (without seconds) (15:37)
-
-    **%S** Seconds (00, ..., 59)
-
-    **%T** 24-hour time of day (15:37:40)
-
-    **%w** Numeric day of week (0, ..., 6)
-
-    **%Y** Year
-
-    **%y** 2-digit year
-
-    **%%** Percent-sign
-"""
+/// Formats a timestamp into a string, using the format specified.
+///
+/// The follow format specifiers are supported:
+///
+/// **%A** Day of the week (Sunday, Monday, ...)
+///
+/// **%a** Short day of the week (Sun, Mon, ...)
+///
+/// **%B** Month (January, February, ...)
+///
+/// **%b %h** Short month (Jan, Feb, ...)
+///
+/// **%d %e** Day of the month (01, ..., 31)
+///
+/// **%D** Full day (08/31/2023)
+///
+/// **%H** Hour (00, ..., 23)
+///
+/// **%I** 12-hour Hour (12, 01, ..., 11, 12)
+///
+/// **%j** Day of the year (0, ..., 364)
+///
+/// **%m** Month number (01, 02, ... 12)
+///
+/// **%M** Minute (00, ..., 59)
+///
+/// **%p** AM/PM signifier
+///
+/// **%r** 12-hour time of day (12:15:39 pm)
+///
+/// **%R** 24-hour time of day (without seconds) (15:37)
+///
+/// **%S** Seconds (00, ..., 59)
+///
+/// **%T** 24-hour time of day (15:37:40)
+///
+/// **%w** Numeric day of week (0, ..., 6)
+///
+/// **%Y** Year
+///
+/// **%y** 2-digit year
+///
+/// **%%** Percent-sign
 #overload
 strftime :: (format_: [] u8, tm: &Timestamp) -> str {
     s := io.buffer_stream_make();
@@ -255,9 +245,7 @@ strftime :: (w: &io.Writer, format_: [] u8, tm: &Timestamp) {
 
 strptime :: #match #local {}
 
-#doc """
-    Parses a string into a `Timestamp`.
-"""
+/// Parses a string into a `Timestamp`.
 #overload
 strptime :: (buf: [] u8, format: [] u8) -> ? Timestamp {
     t: Timestamp;
@@ -269,9 +257,7 @@ strptime :: (buf: [] u8, format: [] u8) -> ? Timestamp {
     return .None;
 }
 
-#doc """
-    Parses a string into a `Timestamp`. Returns `true` if the parsing was successful.
-"""
+/// Parses a string into a `Timestamp`. Returns `true` if the parsing was successful.
 #overload
 strptime :: (buf_: [] u8, format_: [] u8, tm: &Timestamp) -> bool {
     use core {*}


### PR DESCRIPTION
This pull request changes the way that documentation is provided for top-level symbols. It deprecates the `#doc` directive in favor *documentation comments*, or comments that start with `///`. This is generally easier to read, and much simpler to type. It should have been what was originally done, but `#doc` was *slightly* simpler for me to implement, and I think I was feeling lazy that day.