### PR TITLE
Switch to mapped directories instead of a search path

### DIFF
--- a/compiler/include/astnodes.h
+++ b/compiler/include/astnodes.h
@@ -1999,7 +1999,7 @@ struct CompileOptions {
 
     Runtime runtime;
 
-    bh_arr(const char *) included_folders;
+    bh_arr(bh_mapped_folder) mapped_folders;
     bh_arr(const char *) files;
     const char* target_file;
     const char* documentation_file;

--- a/compiler/src/checker.c
+++ b/compiler/src/checker.c
@@ -3913,7 +3913,7 @@ CheckStatus check_process_directive(AstNode* directive) {
 
             char *path = bh_strdup(
                 global_scratch_allocator,
-                bh_lookup_file(temp_str, parent_folder, "", 0, NULL, 0)
+                bh_lookup_file(temp_str, parent_folder, NULL, NULL, NULL)
             );
 
             if (!bh_file_exists(path)) {

--- a/compiler/src/cli.c
+++ b/compiler/src/cli.c
@@ -68,7 +68,7 @@ static const char *build_docstring = DOCSTRING_HEADER
     C_BOLD "Flags:\n" C_NORM
     C_LBLUE "    -o, --output " C_GREY "target_file    " C_NORM "Specify the target file " C_GREY "(default: out.wasm)\n"
     C_LBLUE "    -r, --runtime " C_GREY "runtime       " C_NORM "Specifies the runtime " C_GREY "(onyx, wasi, js, custom)\n"
-    C_LBLUE "    -I, --include " C_GREY "dir           " C_NORM "Include a directory in the search path\n"
+    C_LBLUE "    --map-dir " C_GREY "name:folder       " C_NORM "Adds a mapped directory\n"
     "\n"
     C_LBLUE "    --debug                     " C_NORM "Output a debugable build\n"
     C_LBLUE "    --feature " C_GREY "feature           " C_NORM "Enable an experimental language feature\n"
@@ -320,7 +320,24 @@ static void cli_parse_compilation_options(CompileOptions *options, int arg_parse
             }
         }
         else if (!strcmp(argv[i], "-I") || !strcmp(argv[i], "--include")) {
-            bh_arr_push(options->included_folders, argv[++i]);
+            OnyxFilePos fp = {0};
+            onyx_report_warning(fp, "%s has been removed in favor of --map-dir", argv[i++]);
+        }
+        else if (!strcmp(argv[i], "--map-dir")) {
+            char *arg = argv[++i];
+            int len = strnlen(arg, 256);
+
+            char *name = arg;
+            char *folder = NULL;
+            fori (i, 0, len) if (arg[i] == ':') {
+                arg[i] = '\0';
+                folder = &arg[i + 1];
+            }
+
+            bh_mapped_folder mf;
+            mf.name = name;
+            mf.folder = folder;
+            bh_arr_push(options->mapped_folders, mf);
         }
         else if (!strncmp(argv[i], "-D", 2)) {
             i32 len = strlen(argv[i]);
@@ -477,7 +494,7 @@ static CompileOptions compile_opts_parse(bh_allocator alloc, int argc, char *arg
     };
 
     bh_arr_new(alloc, options.files, 2);
-    bh_arr_new(alloc, options.included_folders, 2);
+    bh_arr_new(alloc, options.mapped_folders, 2);
     bh_arr_new(alloc, options.defined_variables, 2);
 
     #if defined(_BH_LINUX) || defined(_BH_DARWIN)
@@ -505,9 +522,10 @@ static CompileOptions compile_opts_parse(bh_allocator alloc, int argc, char *arg
         exit(1);
     }
 
-    // NOTE: Add the current folder
-    bh_arr_push(options.included_folders, options.core_installation);
-    bh_arr_push(options.included_folders, ".");
+    bh_arr_push(options.mapped_folders, ((bh_mapped_folder) {
+        .name = "core",
+        .folder = bh_aprintf(alloc, "%s/core", options.core_installation)
+    }));
 
     if (argc == 1) return options;
 
@@ -565,7 +583,7 @@ static CompileOptions compile_opts_parse(bh_allocator alloc, int argc, char *arg
 
 static void compile_opts_free(CompileOptions* opts) {
     bh_arr_free(opts->files);
-    bh_arr_free(opts->included_folders);
+    bh_arr_free(opts->mapped_folders);
 }
 
 static void print_subcommand_help(const char *subcommand) {

--- a/compiler/src/extensions.c
+++ b/compiler/src/extensions.c
@@ -191,10 +191,9 @@ TypeMatch compiler_extension_start(const char *name, const char *containing_file
     if (*out_extension_id == 0) {
         char* parent_folder = bh_path_get_parent(containing_filename, global_scratch_allocator);
 
-        // CLEANUP: Should the include folders be different than the other include files list?
         char *path = bh_strdup(
                 global_scratch_allocator,
-                bh_lookup_file((char *) name, parent_folder, ".wasm", 0, context.options->included_folders, 0)
+                bh_lookup_file((char *) name, parent_folder, NULL, NULL, NULL)
         );
 
         if (!bh_file_exists(path)) {

--- a/compiler/src/onyx.c
+++ b/compiler/src/onyx.c
@@ -128,14 +128,14 @@ static void context_init(CompileOptions* opts) {
         .state = Entity_State_Parse_Builtin,
         .type = Entity_Type_Load_File,
         .package = NULL,
-        .include = create_load(context.ast_alloc, "core/builtin"),
+        .include = create_load(context.ast_alloc, "core:builtin"),
     }));
 
     entity_heap_insert(&context.entities, ((Entity) {
         .state = Entity_State_Parse_Builtin,
         .type = Entity_Type_Load_File,
         .package = NULL,
-        .include = create_load(context.ast_alloc, "core/runtime/build_opts"),
+        .include = create_load(context.ast_alloc, "core:runtime/build_opts"),
     }));
 
     if (context.options->runtime != Runtime_Custom) {
@@ -143,31 +143,31 @@ static void context_init(CompileOptions* opts) {
             .state = Entity_State_Parse,
             .type = Entity_Type_Load_File,
             .package = NULL,
-            .include = create_load(context.ast_alloc, "core/runtime/info/types"),
+            .include = create_load(context.ast_alloc, "core:runtime/info/types"),
         }));
         runtime_info_foreign_entity = entity_heap_insert(&context.entities, ((Entity) {
             .state = Entity_State_Parse,
             .type = Entity_Type_Load_File,
             .package = NULL,
-            .include = create_load(context.ast_alloc, "core/runtime/info/foreign_blocks"),
+            .include = create_load(context.ast_alloc, "core:runtime/info/foreign_blocks"),
         }));
         runtime_info_proc_tags_entity = entity_heap_insert(&context.entities, ((Entity) {
             .state = Entity_State_Parse,
             .type = Entity_Type_Load_File,
             .package = NULL,
-            .include = create_load(context.ast_alloc, "core/runtime/info/proc_tags"),
+            .include = create_load(context.ast_alloc, "core:runtime/info/proc_tags"),
         }));
         runtime_info_global_tags_entity = entity_heap_insert(&context.entities, ((Entity) {
             .state = Entity_State_Parse,
             .type = Entity_Type_Load_File,
             .package = NULL,
-            .include = create_load(context.ast_alloc, "core/runtime/info/global_tags"),
+            .include = create_load(context.ast_alloc, "core:runtime/info/global_tags"),
         }));
         runtime_info_stack_trace_entity = entity_heap_insert(&context.entities, ((Entity) {
             .state = Entity_State_Parse,
             .type = Entity_Type_Load_File,
             .package = NULL,
-            .include = create_load(context.ast_alloc, "core/runtime/info/stack_trace"),
+            .include = create_load(context.ast_alloc, "core:runtime/info/stack_trace"),
         }));
     }
 
@@ -195,7 +195,7 @@ static void context_init(CompileOptions* opts) {
             .state = Entity_State_Parse,
             .type = Entity_Type_Load_File,
             .package = NULL,
-            .include = create_load(context.ast_alloc, "core/module"),
+            .include = create_load(context.ast_alloc, "core:module"),
         }));
     }
 
@@ -216,9 +216,9 @@ static void context_init(CompileOptions* opts) {
     }
 
     if (context.options->verbose_output > 0) {
-        bh_printf("File search path:\n");
-        bh_arr_each(const char *, p, context.options->included_folders) {
-            bh_printf("\t%s\n", *p);
+        bh_printf("Mapped folders:\n");
+        bh_arr_each(bh_mapped_folder, p, context.options->mapped_folders) {
+            bh_printf("\t%s: %s\n", p->name, p->folder);
         }
         bh_printf("\n");
     }
@@ -284,7 +284,7 @@ static b32 process_load_entity(Entity* ent) {
 
         char* parent_folder = bh_path_get_parent(parent_file, global_scratch_allocator);
 
-        char* filename = bh_lookup_file(include->name, parent_folder, ".onyx", 1, context.options->included_folders, 1);
+        char* filename = bh_lookup_file(include->name, parent_folder, ".onyx", NULL, context.options->mapped_folders);
         char* formatted_name = bh_strdup(global_heap_allocator, filename);
 
         return process_source_file(formatted_name, include->token->pos);
@@ -348,7 +348,7 @@ static b32 process_load_entity(Entity* ent) {
         return 1;
 
     } else if (include->kind == Ast_Kind_Load_Path) {
-        bh_arr_push(context.options->included_folders, include->name);
+        // bh_arr_push(context.options->included_folders, include->name);
 
     } else if (include->kind == Ast_Kind_Library_Path) {
         bh_arr_push(context.wasm_module->library_paths, include->name);

--- a/compiler/src/onyx.c
+++ b/compiler/src/onyx.c
@@ -348,7 +348,7 @@ static b32 process_load_entity(Entity* ent) {
         return 1;
 
     } else if (include->kind == Ast_Kind_Load_Path) {
-        // bh_arr_push(context.options->included_folders, include->name);
+        onyx_report_warning(include->token->pos, "'#load_path' has been deprecated and no longer does anything.");
 
     } else if (include->kind == Ast_Kind_Library_Path) {
         bh_arr_push(context.wasm_module->library_paths, include->name);

--- a/compiler/src/wasm_emit.c
+++ b/compiler/src/wasm_emit.c
@@ -5209,7 +5209,7 @@ static void emit_file_contents(OnyxWasmModule* mod, AstFileContents* fc) {
         token_toggle_end(filename_token);
         char* temp_fn     = bh_alloc_array(global_scratch_allocator, char, filename_token->length);
         i32   temp_fn_len = string_process_escape_seqs(temp_fn, filename_token->text, filename_token->length);
-        char* filename    = bh_lookup_file(temp_fn, parent_folder, "", 0, NULL, 0);
+        char* filename    = bh_lookup_file(temp_fn, parent_folder, NULL, NULL, NULL);
         fc->filename      = bh_strdup(global_heap_allocator, filename);
         token_toggle_end(filename_token);
     }
@@ -5270,7 +5270,7 @@ static void emit_js_node(OnyxWasmModule* mod, AstJsNode *js) {
         i32   temp_fn_len = string_process_escape_seqs(temp_fn, filename_token->text, filename_token->length);
         char* filename    = bh_strdup(
             global_heap_allocator,
-            bh_lookup_file(temp_fn, parent_folder, "", 0, NULL, 0)
+            bh_lookup_file(temp_fn, parent_folder, NULL, NULL, NULL)
         );
 
         token_toggle_end(filename_token);

--- a/compiler/src/wasm_runtime.c
+++ b/compiler/src/wasm_runtime.c
@@ -105,15 +105,15 @@ static void *locate_symbol_in_dynamic_library(LinkLibraryContext *ctx, char *lib
     char *library_name;
 
     #ifdef _BH_LINUX
-    library_name = bh_lookup_file(libname, ".", ".so", 1, (const char **) ctx->library_paths, 1);
+    library_name = bh_lookup_file(libname, ".", ".so", (const char **) ctx->library_paths, NULL);
     #endif
 
     #ifdef _BH_DARWIN
-    library_name = bh_lookup_file(libname, ".", ".dylib", 1, (const char **) ctx->library_paths, 1);
+    library_name = bh_lookup_file(libname, ".", ".dylib", (const char **) ctx->library_paths, NULL);
     #endif
 
     #ifdef _BH_WINDOWS
-    library_name = bh_lookup_file(libname, ".", ".dll", 1, (const char **) ctx->library_paths, 1);
+    library_name = bh_lookup_file(libname, ".", ".dll", (const char **) ctx->library_paths, NULL);
     #endif
 
     return locate_symbol_in_dynamic_library_raw(library_name, sym);

--- a/core/alloc/heap.onyx
+++ b/core/alloc/heap.onyx
@@ -19,7 +19,7 @@ use core
 #local Enable_Clear_Freed_Memory :: #defined(runtime.vars.Enable_Heap_Clear_Freed_Memory)
 #local Enable_Stack_Trace :: runtime.Stack_Trace_Enabled
 
-#load "core/intrinsics/wasm"
+#load "core:intrinsics/wasm"
 
 #if runtime.Multi_Threading_Enabled {
     use core {sync}

--- a/core/runtime/platform/onyx/platform.onyx
+++ b/core/runtime/platform/onyx/platform.onyx
@@ -13,9 +13,9 @@ use runtime {
 #load "./env"
 #load "./net"
 
-#load "core/onyx/cptr"
-#load "core/onyx/cbindgen"
-// #load "core/onyx/fault_handling"
+#load "core:onyx/cptr"
+#load "core:onyx/cbindgen"
+// #load "core:onyx/fault_handling"
 
 // Platform supports
 Supports_Files :: true

--- a/examples/01_hello_world.onyx
+++ b/examples/01_hello_world.onyx
@@ -14,7 +14,7 @@ package main
 // option to disable loading the standard library, if that is needed. For the sake
 // of completeness, the following line manually includes the standard library, but
 // this is not necessary.
-#load "core/module"
+
 
 
 // To use packages, use the 'use' keyword. The 'core' package houses all of the

--- a/examples/02_variables.onyx
+++ b/examples/02_variables.onyx
@@ -1,4 +1,4 @@
-// Notice this time, we are not adding, 'package main' or '#load "core/module"'
+// Notice this time, we are not adding, 'package main' or ''
 // to the top of the file, since every file is automatically part of the
 // main package unless specified otherwise, and every compilations includes
 // the standard library.

--- a/examples/04_fixed_arrays.onyx
+++ b/examples/04_fixed_arrays.onyx
@@ -15,7 +15,7 @@
 // This file will give examples of all of these things, as well as some of the gotchas
 // you need to be aware of.
 
-#load "core/module"
+
 
 use core {*}
 

--- a/examples/05_slices.onyx
+++ b/examples/05_slices.onyx
@@ -5,7 +5,7 @@
 // is a powerful construct to have. In fact, strings in Onyx, i.e.
 // the 'str' type, is actually just a slice of u8.
 
-#load "core/module"
+
 
 use core {*}
 

--- a/examples/06_dynamic_arrays.onyx
+++ b/examples/06_dynamic_arrays.onyx
@@ -7,7 +7,7 @@
 // Dynamic arrays in Onyx are easy to use on purpose, because I
 // know how useful they are in almost every program I write.
 
-#load "core/module"
+
 
 use core {*}
 

--- a/examples/07_structs.onyx
+++ b/examples/07_structs.onyx
@@ -5,7 +5,7 @@
 // 'structs' in Onyx are very similar to structs in C and C++, with a couple
 // of additional capabilities to make using them even easier.
 
-#load "core/module"
+
 
 use core {*}
 

--- a/examples/08_enums.onyx
+++ b/examples/08_enums.onyx
@@ -4,7 +4,7 @@
 // expressions. This is going to improve in the future, but for the moment,
 // enums are rather limited.
 
-#load "core/module"
+
 
 use core {*}
 

--- a/examples/09_for_loops.onyx
+++ b/examples/09_for_loops.onyx
@@ -4,7 +4,7 @@
 // in Onyx are extremely simple to use by design and should make programming very
 // enjoyable. But I digress, let's look at some examples.
 
-#load "core/module"
+
 
 use core {package, *}
 

--- a/examples/10_switch_statements.onyx
+++ b/examples/10_switch_statements.onyx
@@ -1,4 +1,4 @@
-#load "core/module"
+
 
 use core {*}
 

--- a/examples/11_map.onyx
+++ b/examples/11_map.onyx
@@ -1,4 +1,4 @@
-#load "core/module"
+
 
 use core {*}
 

--- a/examples/12_varargs.onyx
+++ b/examples/12_varargs.onyx
@@ -15,7 +15,7 @@
 //   - 'variadic argument' is shortened to 'vararg' in many situtations
 
 
-#load "core/module"
+
 
 use core {*}
 

--- a/examples/13_use_keyword.onyx
+++ b/examples/13_use_keyword.onyx
@@ -14,7 +14,7 @@
 // most cases, but can easily break and require you to write the code without it. This
 // is being address and hopefully in the next couple months it will be much more robust.
 
-#load "core/module"
+
 
 use core {*}
 

--- a/examples/14_overloaded_procs.onyx
+++ b/examples/14_overloaded_procs.onyx
@@ -32,7 +32,7 @@
 // Let's look at some examples of overloaded procedures and how they are resolved.
 
 
-#load "core/module"
+
 
 use core {*}
 

--- a/examples/15_polymorphic_procs.onyx
+++ b/examples/15_polymorphic_procs.onyx
@@ -57,7 +57,7 @@ compose :: (a: $A, f: (A) -> $B, g: (B) -> $C) -> C {
 
 }
 
-#load "core/module"
+
 
 use core {*}
 

--- a/examples/16_pipe_operator.onyx
+++ b/examples/16_pipe_operator.onyx
@@ -1,4 +1,4 @@
-#load "core/module"
+
 
 use core { println }
 

--- a/examples/17_operator_overload.onyx
+++ b/examples/17_operator_overload.onyx
@@ -1,4 +1,4 @@
-#load "core/module"
+
 use core {*}
 
 // Operator overloading allows you to define what it means to perform

--- a/examples/18_macros.onyx
+++ b/examples/18_macros.onyx
@@ -134,5 +134,5 @@ main :: (args: [] cstr) {
     //     }
 }
 
-#load "core/module"
+
 use core {*}

--- a/examples/19_do_blocks.onyx
+++ b/examples/19_do_blocks.onyx
@@ -65,5 +65,5 @@ main :: (args: [] cstr) {
 
 }
 
-#load "core/module"
+
 use core {*}

--- a/examples/20_auto_return.onyx
+++ b/examples/20_auto_return.onyx
@@ -42,6 +42,6 @@ main :: (args: [] cstr) {
     println(arr);
 }
 
-#load "core/module"
+
 use core {*}
 

--- a/examples/21_quick_functions.onyx
+++ b/examples/21_quick_functions.onyx
@@ -44,5 +44,5 @@ main :: (args) => {
     println(val);
 }
 
-#load "core/module"
+
 use core {*}

--- a/examples/22_interfaces.onyx
+++ b/examples/22_interfaces.onyx
@@ -140,6 +140,6 @@ main :: (args) => {
     overloaded_procedure_example();
 }
 
-#load "core/module"
+
 use core {*}
 use core.intrinsics.onyx {*}

--- a/examples/50_misc.onyx
+++ b/examples/50_misc.onyx
@@ -66,5 +66,5 @@ main :: (args) => {
     multiple_declaration_improvements();
 }
 
-#load "core/module"
+
 use core {*}

--- a/scripts/core_tests.onyx
+++ b/scripts/core_tests.onyx
@@ -1,6 +1,6 @@
 
 
-#load "core/module"
+
 
 use core {package, test}
 

--- a/scripts/onyx-pkg.onyx
+++ b/scripts/onyx-pkg.onyx
@@ -1,6 +1,6 @@
 
-#load "core/module"
-#load "core/encoding/ini"
+
+#load "core:encoding/ini"
 
 //
 // A list of repository URLs to get packages from.

--- a/shared/include/bh.h
+++ b/shared/include/bh.h
@@ -468,9 +468,16 @@ char* bh_path_get_full_name(char const* filename, bh_allocator a);
 char* bh_path_get_parent(char const* filename, bh_allocator a);
 char* bh_path_convert_separators(char* path);
 
+
+typedef struct bh_mapped_folder {
+    char *name;
+    char *folder;
+} bh_mapped_folder;
+
 // This function returns a volatile pointer. Do not store it without copying!
 // `included_folders` is bh_arr(const char *).
-char* bh_lookup_file(char* filename, char* relative_to, char *suffix, b32 add_suffix, const char ** included_folders, b32 search_included_folders);
+// 'mapped_folders' is bh_arr(bh_mapped_folder).
+char* bh_lookup_file(char* filename, char* relative_to, char *suffix, const char ** included_folders, bh_mapped_folder* mapped_folders);
 
 #define bh_file_read_contents(allocator_, x) _Generic((x), \
     bh_file*: bh_file_read_contents_bh_file, \
@@ -2022,7 +2029,13 @@ char* bh_path_get_parent(char const* filename, bh_allocator a) {
 }
 
 // This function returns a volatile pointer. Do not store it without copying!
-char* bh_lookup_file(char* filename, char* relative_to, char *suffix, b32 add_suffix, bh_arr(const char *) included_folders, b32 search_included_folders) {
+char* bh_lookup_file(
+    char* filename,
+    char* relative_to,
+    char *suffix,
+    bh_arr(const char *) included_folders,
+    bh_arr(bh_mapped_folder) mapped_folders
+) {
     assert(relative_to != NULL);
 
     static char path[512];
@@ -2031,13 +2044,18 @@ char* bh_lookup_file(char* filename, char* relative_to, char *suffix, b32 add_su
     static char fn[256];
     fori (i, 0, 256) fn[i] = 0;
 
-    if (!bh_str_ends_with(filename, suffix) && add_suffix) {
+    if (suffix && !bh_str_ends_with(filename, suffix)) {
         bh_snprintf(fn, 256, "%s%s", filename, suffix);
     } else {
         bh_snprintf(fn, 256, "%s", filename);
     }
 
-    fori (i, 0, 256) if (fn[i] == '/') fn[i] = DIR_SEPARATOR;
+    b32 contains_colon = 0;
+
+    fori (i, 0, 256) {
+        if (fn[i] == ':') contains_colon = 1;
+        if (fn[i] == '/') fn[i] = DIR_SEPARATOR;
+    }
 
     if (bh_str_starts_with(filename, "./")) {
         if (relative_to[strlen(relative_to) - 1] != DIR_SEPARATOR)
@@ -2050,7 +2068,36 @@ char* bh_lookup_file(char* filename, char* relative_to, char *suffix, b32 add_su
         return path;
     }
 
-    if (search_included_folders) {
+    if (contains_colon && mapped_folders) {
+        char *source_name = fn;
+        char *subpath     = NULL;
+
+        fori (i, 0, 256) {
+            if (fn[i] == ':') {
+                fn[i] = '\0';
+                subpath = &fn[i + 1];
+                break;
+            }
+        }
+
+        assert(subpath);
+
+        bh_arr_each(bh_mapped_folder, folder, mapped_folders) {
+            if (!strncmp(source_name, folder->name, 256)) {
+                if (folder->folder[strlen(folder->folder) - 1] != DIR_SEPARATOR)
+                    bh_snprintf(path, 512, "%s%c%s", folder->folder, DIR_SEPARATOR, subpath);
+                else
+                    bh_snprintf(path, 512, "%s%s", folder->folder, subpath);
+
+                if (bh_file_exists(path))
+                    return bh_path_get_full_name(path, BH_INTERNAL_ALLOCATOR);
+
+                break;
+            }
+        }
+    }
+
+    else if (included_folders) {
         bh_arr_each(const char *, folder, included_folders) {
             if ((*folder)[strlen(*folder) - 1] != DIR_SEPARATOR)
                 bh_snprintf(path, 512, "%s%c%s", *folder, DIR_SEPARATOR, fn);
@@ -2061,7 +2108,7 @@ char* bh_lookup_file(char* filename, char* relative_to, char *suffix, b32 add_su
         }
     }
 
-    return fn;
+    return bh_path_get_full_name(fn, BH_INTERNAL_ALLOCATOR);
 }
 
 //

--- a/tests/aoc-2020/day1.onyx
+++ b/tests/aoc-2020/day1.onyx
@@ -1,4 +1,4 @@
-#load "core/module"
+
 
 use core
 use core.io

--- a/tests/aoc-2020/day10.onyx
+++ b/tests/aoc-2020/day10.onyx
@@ -1,4 +1,4 @@
-#load "core/module"
+
 
 use core {*}
 

--- a/tests/aoc-2020/day12.onyx
+++ b/tests/aoc-2020/day12.onyx
@@ -1,4 +1,4 @@
-#load "core/module"
+
 
 use core {*}
 

--- a/tests/aoc-2020/day13.onyx
+++ b/tests/aoc-2020/day13.onyx
@@ -1,4 +1,4 @@
-#load "core/module"
+
 
 use core {*}
 

--- a/tests/aoc-2020/day14.onyx
+++ b/tests/aoc-2020/day14.onyx
@@ -1,4 +1,4 @@
-#load "core/module"
+
 
 use core {*}
 

--- a/tests/aoc-2020/day15.onyx
+++ b/tests/aoc-2020/day15.onyx
@@ -1,4 +1,4 @@
-#load "core/module"
+
 
 use core {*}
 

--- a/tests/aoc-2020/day16.onyx
+++ b/tests/aoc-2020/day16.onyx
@@ -1,4 +1,4 @@
-#load "core/module"
+
 
 use core {*}
 

--- a/tests/aoc-2020/day17.onyx
+++ b/tests/aoc-2020/day17.onyx
@@ -1,4 +1,4 @@
-#load "core/module"
+
 
 use core {package, *}
 

--- a/tests/aoc-2020/day18.onyx
+++ b/tests/aoc-2020/day18.onyx
@@ -1,4 +1,4 @@
-#load "core/module"
+
 
 use core {*}
 

--- a/tests/aoc-2020/day19.onyx
+++ b/tests/aoc-2020/day19.onyx
@@ -1,4 +1,4 @@
-#load "core/module"
+
 
 use core {*}
 

--- a/tests/aoc-2020/day2.onyx
+++ b/tests/aoc-2020/day2.onyx
@@ -1,6 +1,6 @@
 package main
 
-#load "core/module"
+
 
 use core {*}
 

--- a/tests/aoc-2020/day20.onyx
+++ b/tests/aoc-2020/day20.onyx
@@ -1,4 +1,4 @@
-#load "core/module"
+
 
 use core {*}
 

--- a/tests/aoc-2020/day21.onyx
+++ b/tests/aoc-2020/day21.onyx
@@ -1,4 +1,4 @@
-#load "core/module"
+
 
 use core {*}
 

--- a/tests/aoc-2020/day22.onyx
+++ b/tests/aoc-2020/day22.onyx
@@ -1,4 +1,4 @@
-#load "core/module"
+
 
 use core {*}
 

--- a/tests/aoc-2020/day23.onyx
+++ b/tests/aoc-2020/day23.onyx
@@ -1,4 +1,4 @@
-#load "core/module"
+
 
 use core {*}
 

--- a/tests/aoc-2020/day24.onyx
+++ b/tests/aoc-2020/day24.onyx
@@ -1,4 +1,4 @@
-#load "core/module"
+
 
 use core {*}
 

--- a/tests/aoc-2020/day25.onyx
+++ b/tests/aoc-2020/day25.onyx
@@ -1,4 +1,4 @@
-#load "core/module"
+
 
 use core {*}
 

--- a/tests/aoc-2020/day3.onyx
+++ b/tests/aoc-2020/day3.onyx
@@ -1,4 +1,4 @@
-#load "core/module"
+
 
 use core {*}
 

--- a/tests/aoc-2020/day4.onyx
+++ b/tests/aoc-2020/day4.onyx
@@ -1,4 +1,4 @@
-#load "core/module"
+
 
 use core {*}
 

--- a/tests/aoc-2020/day5.onyx
+++ b/tests/aoc-2020/day5.onyx
@@ -1,4 +1,4 @@
-#load "core/module"
+
 
 use core {*}
 

--- a/tests/aoc-2020/day6.onyx
+++ b/tests/aoc-2020/day6.onyx
@@ -1,4 +1,4 @@
-#load "core/module"
+
 
 use core {*}
 

--- a/tests/aoc-2020/day7.onyx
+++ b/tests/aoc-2020/day7.onyx
@@ -1,4 +1,4 @@
-#load "core/module"
+
 
 use core {*}
 

--- a/tests/aoc-2020/day8.onyx
+++ b/tests/aoc-2020/day8.onyx
@@ -1,4 +1,4 @@
-#load "core/module"
+
 
 use core {*}
 

--- a/tests/aoc-2020/day9.onyx
+++ b/tests/aoc-2020/day9.onyx
@@ -1,4 +1,4 @@
-#load "core/module"
+
 
 use core {*}
 

--- a/tests/aoc-2021/day01.onyx
+++ b/tests/aoc-2021/day01.onyx
@@ -1,4 +1,4 @@
-#load "core/module"
+
 
 use core.io
 use core.os

--- a/tests/aoc-2021/day03.onyx
+++ b/tests/aoc-2021/day03.onyx
@@ -1,6 +1,6 @@
 PART :: 2
 
-#load "core/module"
+
 
 use core {*}
 

--- a/tests/aoc-2021/day05.onyx
+++ b/tests/aoc-2021/day05.onyx
@@ -1,4 +1,4 @@
-#load "core/module"
+
 
 use core {*}
 

--- a/tests/aoc-2021/day06.onyx
+++ b/tests/aoc-2021/day06.onyx
@@ -1,4 +1,4 @@
-#load "core/module"
+
 
 use core {*}
 

--- a/tests/aoc-2021/day07.onyx
+++ b/tests/aoc-2021/day07.onyx
@@ -1,4 +1,4 @@
-#load "core/module"
+
 
 use core {*}
 

--- a/tests/aoc-2021/day08.onyx
+++ b/tests/aoc-2021/day08.onyx
@@ -1,5 +1,5 @@
 PART :: 2
-#load "core/module"
+
 
 use core {*}
 

--- a/tests/aoc-2021/day09.onyx
+++ b/tests/aoc-2021/day09.onyx
@@ -1,4 +1,4 @@
-#load "core/module"
+
 
 use core {*}
 

--- a/tests/aoc-2021/day10.onyx
+++ b/tests/aoc-2021/day10.onyx
@@ -1,4 +1,4 @@
-#load "core/module"
+
 
 use core {*}
 

--- a/tests/aoc-2021/day11.onyx
+++ b/tests/aoc-2021/day11.onyx
@@ -1,4 +1,4 @@
-#load "core/module"
+
 
 use core {*}
 

--- a/tests/aoc-2021/day12.onyx
+++ b/tests/aoc-2021/day12.onyx
@@ -1,4 +1,4 @@
-#load "core/module"
+
 
 use core {*}
 

--- a/tests/aoc-2021/day13.onyx
+++ b/tests/aoc-2021/day13.onyx
@@ -1,4 +1,4 @@
-#load "core/module"
+
 
 use core {*}
 

--- a/tests/aoc-2021/day14.onyx
+++ b/tests/aoc-2021/day14.onyx
@@ -1,4 +1,4 @@
-#load "core/module"
+
 
 use core {*}
 

--- a/tests/aoc-2021/day15.onyx
+++ b/tests/aoc-2021/day15.onyx
@@ -1,4 +1,4 @@
-#load "core/module"
+
 
 use core {*}
 

--- a/tests/aoc-2021/day16.onyx
+++ b/tests/aoc-2021/day16.onyx
@@ -1,4 +1,4 @@
-#load "core/module"
+
 
 use core {*}
 

--- a/tests/aoc-2021/day17.onyx
+++ b/tests/aoc-2021/day17.onyx
@@ -1,4 +1,4 @@
-#load "core/module"
+
 
 use core {*}
 

--- a/tests/aoc-2021/day18.onyx
+++ b/tests/aoc-2021/day18.onyx
@@ -1,4 +1,4 @@
-#load "core/module"
+
 
 PART :: 2
 

--- a/tests/array_accessors.onyx
+++ b/tests/array_accessors.onyx
@@ -1,4 +1,4 @@
-#load "core/module"
+
 
 use core {*}
 

--- a/tests/array_programming.onyx
+++ b/tests/array_programming.onyx
@@ -1,4 +1,4 @@
-#load "core/module"
+
 
 use core {*}
 

--- a/tests/array_struct_robustness.onyx
+++ b/tests/array_struct_robustness.onyx
@@ -1,4 +1,4 @@
-#load "core/module"
+
 
 use core {*}
 

--- a/tests/arrow_notation.onyx
+++ b/tests/arrow_notation.onyx
@@ -1,4 +1,4 @@
-#load "core/module"
+
 
 use core
 use core.conv

--- a/tests/atomics.onyx
+++ b/tests/atomics.onyx
@@ -1,5 +1,5 @@
-#load "core/module"
-#load "core/intrinsics/atomics"
+
+#load "core:intrinsics/atomics"
 
 use core {*}
 use core.intrinsics.atomics {*}

--- a/tests/auto_poly.onyx
+++ b/tests/auto_poly.onyx
@@ -1,4 +1,4 @@
-#load "core/module"
+
 
 use core {*}
 

--- a/tests/avl_test.onyx
+++ b/tests/avl_test.onyx
@@ -1,4 +1,4 @@
-#load "core/module"
+
 
 use core {*}
 

--- a/tests/baked_parameters.onyx
+++ b/tests/baked_parameters.onyx
@@ -1,4 +1,4 @@
-#load "core/module"
+
 
 use core {*}
 

--- a/tests/better_field_accesses.onyx
+++ b/tests/better_field_accesses.onyx
@@ -1,4 +1,4 @@
-#load "core/module"
+
 
 use core {*}
 

--- a/tests/bucket_array.onyx
+++ b/tests/bucket_array.onyx
@@ -1,4 +1,4 @@
-#load "core/module"
+
 
 use core {*}
 

--- a/tests/bugs/anonymous_struct_defaults.onyx
+++ b/tests/bugs/anonymous_struct_defaults.onyx
@@ -1,4 +1,4 @@
-#load "core/module"
+
 
 use core {*}
 

--- a/tests/bugs/array_lengths.onyx
+++ b/tests/bugs/array_lengths.onyx
@@ -1,4 +1,4 @@
-#load "core/module"
+
 
 use core { * }
 

--- a/tests/bugs/defer_block_in_macro.onyx
+++ b/tests/bugs/defer_block_in_macro.onyx
@@ -1,4 +1,4 @@
-#load "core/module"
+
 
 use core {*}
 

--- a/tests/bugs/fallthrough_defer_interaction.onyx
+++ b/tests/bugs/fallthrough_defer_interaction.onyx
@@ -1,4 +1,4 @@
-#load "core/module"
+
 
 use core {*}
 

--- a/tests/bugs/macro_auto_return_not_resolved.onyx
+++ b/tests/bugs/macro_auto_return_not_resolved.onyx
@@ -1,4 +1,4 @@
-#load "core/module"
+
 
 use core {*}
 

--- a/tests/bugs/namespace_aliasing.onyx
+++ b/tests/bugs/namespace_aliasing.onyx
@@ -1,4 +1,4 @@
-#load "core/module"
+
 use core {*}
 
 SomeNamespace :: struct {

--- a/tests/caller_location.onyx
+++ b/tests/caller_location.onyx
@@ -1,4 +1,4 @@
-#load "core/module"
+
 
 use core {*}
 

--- a/tests/compile_time_procedures.onyx
+++ b/tests/compile_time_procedures.onyx
@@ -1,4 +1,4 @@
-#load "core/module"
+
 
 use core {*}
 

--- a/tests/complicated_polymorph.onyx
+++ b/tests/complicated_polymorph.onyx
@@ -1,4 +1,4 @@
-#load "core/module"
+
 
 use core {*}
 

--- a/tests/defer_with_continue.onyx
+++ b/tests/defer_with_continue.onyx
@@ -1,4 +1,4 @@
-#load "core/module"
+
 
 use core {*}
 

--- a/tests/defined_test.onyx
+++ b/tests/defined_test.onyx
@@ -1,4 +1,4 @@
-#load "core/module"
+
 
 use core {*}
 

--- a/tests/float_parsing.onyx
+++ b/tests/float_parsing.onyx
@@ -1,4 +1,4 @@
-#load "core/module"
+
 
 use core {*}
 

--- a/tests/hello_world.onyx
+++ b/tests/hello_world.onyx
@@ -1,6 +1,6 @@
 package main
 
-#load "core/module"
+
 
 use core {*}
 

--- a/tests/i32map.onyx
+++ b/tests/i32map.onyx
@@ -1,6 +1,6 @@
 package main
 
-#load "core/module"
+
 
 use core {*}
 

--- a/tests/if_expressions.onyx
+++ b/tests/if_expressions.onyx
@@ -1,4 +1,4 @@
-#load "core/module"
+
 
 use core {package, println, printf}
 

--- a/tests/implicit_initialize_locals.onyx
+++ b/tests/implicit_initialize_locals.onyx
@@ -1,4 +1,4 @@
-#load "core/module"
+
 
 use core {*}
 

--- a/tests/init_procedures.onyx
+++ b/tests/init_procedures.onyx
@@ -1,4 +1,4 @@
-#load "core/module"
+
 
 use core {*}
 

--- a/tests/interfaces.onyx
+++ b/tests/interfaces.onyx
@@ -1,4 +1,4 @@
-#load "core/module"
+
 
 use core
 use core.hash

--- a/tests/lazy_iterators.onyx
+++ b/tests/lazy_iterators.onyx
@@ -1,4 +1,4 @@
-#load "core/module"
+
 
 use core {*}
 

--- a/tests/multiple_returns_robustness.onyx
+++ b/tests/multiple_returns_robustness.onyx
@@ -1,4 +1,4 @@
-#load "core/module"
+
 
 use core {package, *}
 

--- a/tests/named_arguments_test.onyx
+++ b/tests/named_arguments_test.onyx
@@ -1,4 +1,4 @@
-#load "core/module"
+
 
 use core {*}
 

--- a/tests/new_printf.onyx
+++ b/tests/new_printf.onyx
@@ -1,4 +1,4 @@
-#load "core/module"
+
 
 use core {printf, map}
 

--- a/tests/new_struct_behaviour.onyx
+++ b/tests/new_struct_behaviour.onyx
@@ -1,6 +1,6 @@
 // This is a needlessly complicated test of some of the newer features with structs.
 
-#load "core/module"
+
 
 use core {*}
 

--- a/tests/operator_overload.onyx
+++ b/tests/operator_overload.onyx
@@ -1,4 +1,4 @@
-#load "core/module"
+
 
 use core {*}
 

--- a/tests/overload_precedence.onyx
+++ b/tests/overload_precedence.onyx
@@ -1,4 +1,4 @@
-#load "core/module"
+
 
 use core {*}
 

--- a/tests/overload_with_autocast.onyx
+++ b/tests/overload_with_autocast.onyx
@@ -1,4 +1,4 @@
-#load "core/module"
+
 
 use core
 use core {println}

--- a/tests/persist_locals.onyx
+++ b/tests/persist_locals.onyx
@@ -1,6 +1,6 @@
 // This test does not make a whole ton of sense, but it does thoroughly test the #persist local capability.
 
-#load "core/module"
+
 
 use core {*}
 

--- a/tests/poly_struct_in_type_info.onyx
+++ b/tests/poly_struct_in_type_info.onyx
@@ -1,4 +1,4 @@
-#load "core/module"
+
 
 use core {*}
 use runtime.info

--- a/tests/poly_structs_with_values.onyx
+++ b/tests/poly_structs_with_values.onyx
@@ -1,4 +1,4 @@
-#load "core/module"
+
 
 use core {*}
 

--- a/tests/polymorphic_array_lengths.onyx
+++ b/tests/polymorphic_array_lengths.onyx
@@ -1,4 +1,4 @@
-#load "core/module"
+
 
 use core {*}
 

--- a/tests/remove_test.onyx
+++ b/tests/remove_test.onyx
@@ -1,4 +1,4 @@
-#load "core/module"
+
 
 use core {*}
 

--- a/tests/sets.onyx
+++ b/tests/sets.onyx
@@ -1,4 +1,4 @@
-#load "core/module"
+
 
 use core {*}
 

--- a/tests/string_stream_test.onyx
+++ b/tests/string_stream_test.onyx
@@ -1,4 +1,4 @@
-#load "core/module"
+
 
 use core
 use core.io

--- a/tests/struct_robustness.onyx
+++ b/tests/struct_robustness.onyx
@@ -1,4 +1,4 @@
-#load "core/module"
+
 
 use core {*}
 

--- a/tests/struct_use_pointer_member.onyx
+++ b/tests/struct_use_pointer_member.onyx
@@ -1,4 +1,4 @@
-#load "core/module"
+
 use core {*}
 
 Person_Vtable :: struct {

--- a/tests/switch_using_equals.onyx
+++ b/tests/switch_using_equals.onyx
@@ -1,4 +1,4 @@
-#load "core/module"
+
 
 use core {*}
 

--- a/tests/vararg_test.onyx
+++ b/tests/vararg_test.onyx
@@ -1,6 +1,6 @@
 package main
 
-#load "core/module"
+
 
 use core {*};
 

--- a/tests/where_clauses.onyx
+++ b/tests/where_clauses.onyx
@@ -1,4 +1,4 @@
-#load "core/module"
+
 
 use core {*};
 


### PR DESCRIPTION
This pull request changes how files are searched for in a `#load` directive.

Previously, there was a "search path" that the compiler would append the file's name onto the end of each entry in the search path, and see if that file exists. If so, that file would be used. This was repeated for every entry in the list. By default the only two folders in the search path were the current directory and the `ONYX_PATH`.

Now, `#load` directives must either be relative to the current file (start with `./`), *or* specify a mapped folder name to search from. This way, the programmer is aware of exactly where the file comes from.

In the code, it looks like this:
```odin
// Load the `onyx/compiler_extension.onyx` file from the `core` mapped directory.
#load "core:onyx/compiler_extension"

// ...
```

By default, there is now only one mapped directory called `core`, which points to `ONYX_PATH/core`. You can add mapped directories using the `--map-dir` CLI argument:

```sh
onyx run --map-dir libs:/path/to/libraries main.onyx
```