### PR TITLE
Added parser to allow doc comments in struct members and enum values

### DIFF
--- a/compiler/src/parser.c
+++ b/compiler/src/parser.c
@@ -2729,6 +2729,11 @@ static AstStructType* parse_struct(OnyxParser* parser) {
         bh_arr_clear(member_list_temp);
         while (!consume_token_if_next(parser, ':')) {
             if (parser->hit_unexpected_token) return NULL;
+            if (parser->curr->type == Token_Type_Doc_Comment) {
+                consume_token(parser);
+                continue;
+            }
+
             bh_arr_push(member_list_temp, expect_token(parser, Token_Type_Symbol));
 
             if (parser->curr->type != ':')
@@ -3665,6 +3670,10 @@ static AstEnumType* parse_enum_declaration(OnyxParser* parser) {
 
     while (!consume_token_if_next(parser, '}')) {
         if (parser->hit_unexpected_token) return enum_node;
+        if (parser->curr->type == Token_Type_Doc_Comment) {
+            consume_token(parser);
+            continue;
+        }
 
         AstEnumValue* evalue = make_node(AstEnumValue, Ast_Kind_Enum_Value);
         evalue->token = expect_token(parser, Token_Type_Symbol);


### PR DESCRIPTION
Example Code

```odin
package main

use core {*}

/// An structure of a Point
Point :: struct {
      /// The x position
      x: i32;
      /// The y position
      y: i32;

}

/// Different Colors
Colors :: enum {
    /// Green color
    Green;
    /// Blue color
    Blue;
    /// Red color
    Red;
}

main :: () {

    call :: (point : Point) -> i32 {
        return point.x + point.y
    }

    print :: (point : Point) -> Point {
        println(point)
        return point
    }

    coords := Point.{1, 4}

    println(Colors.Green)

    coords
    |> print()
    |> call()
    |> println()
}
```