### PR TITLE
Add nix flake 

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -4,21 +4,13 @@
   lib,
 }: let
   fs = lib.fileset;
-  sourceFiles = [
-    ./bin
-    ./build.sh
-    ./compiler
-    ./core
-    ./docs
-    ./examples
-    ./interpreter
-    ./misc
-    ./runtime
-    ./scripts
-    ./settings.sh
-    ./shared
-    ./tests
-  ];
+  sourceFiles =
+    fs.difference
+    ./.
+    (fs.unions [
+      (fs.fileFilter (file: file.hasExt "nix") ./.)
+      (fs.fileFilter (file: file.hasExt "bat") ./.)
+    ]);
 in
   fs.trace sourceFiles
   stdenv.mkDerivation {

--- a/default.nix
+++ b/default.nix
@@ -1,0 +1,41 @@
+{
+  stdenv,
+  wasmer,
+  lib,
+}: let
+  fs = lib.fileset;
+  sourceFiles = [
+    ./bin
+    ./build.sh
+    ./compiler
+    ./core
+    ./docs
+    ./examples
+    ./interpreter
+    ./misc
+    ./runtime
+    ./scripts
+    ./settings.sh
+    ./shared
+    ./tests
+  ];
+in
+  fs.trace sourceFiles
+  stdenv.mkDerivation {
+    pname = "onyx";
+    version = "0.1.13";
+
+    src = fs.toSource {
+      root = ./.;
+      fileset = sourceFiles;
+    };
+    buildInputs = [wasmer];
+
+    installPhase = ''
+      runHook preInstall
+      source ./settings.sh
+      export ONYX_INSTALL_DIR=$out/
+      ./build.sh compile install
+      runHook postInstall
+    '';
+  }

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,27 @@
+{
+  "nodes": {
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1737062831,
+        "narHash": "sha256-Tbk1MZbtV2s5aG+iM99U8FqwxU/YNArMcWAv6clcsBc=",
+        "owner": "nixos",
+        "repo": "nixpkgs",
+        "rev": "5df43628fdf08d642be8ba5b3625a6c70731c19c",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nixos",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "nixpkgs": "nixpkgs"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,22 @@
+{
+  description = "Onyx programming language flake";
+
+  inputs = {
+    nixpkgs.url = "github:nixos/nixpkgs?ref=nixos-unstable";
+  };
+
+  outputs = {
+    self,
+    nixpkgs,
+  }: let
+    forAllSys = nixpkgs.lib.genAttrs nixpkgs.lib.platforms.all;
+  in {
+    packages = forAllSys (system: let
+      pkgs = import nixpkgs {inherit system;};
+
+      onyx = pkgs.callPackage ./default.nix {};
+    in {
+      default = onyx;
+    });
+  };
+}


### PR DESCRIPTION
Right now there is no package for Onyx in `nixpkgs`, so it would be nice to at least have a flake you can use from the main repository.

There is still an option to install Onyx in `$HOME/.onyx`, but it is not *the nix way*.

The only thing that can cause trouble is setting up `ONYX_PATH`, but it can be done with next steps:
```shell
# This command returns onyx path in nix-store
nix-store -r $(which onyx)
# Then you can set ONYX_PATH with
export ONYX_PATH=path_to_nix_store 
```