### PR TITLE
multiple interface syntax

### DIFF
--- a/compiler/include/astnodes.h
+++ b/compiler/include/astnodes.h
@@ -1389,6 +1389,11 @@ typedef enum PolyProcLookupMethod {
     PPLM_By_Function_Type,
 } PolyProcLookupMethod;
 
+typedef struct ImplicitInterfaceConstraint {
+    AstNode *interface;
+    bh_arr(AstTyped *) extra_args;  // Arguments after the polymorphic variable
+} ImplicitInterfaceConstraint;
+
 struct AstPolyParam {
     PolyParamKind kind;
 
@@ -1407,8 +1412,9 @@ struct AstPolyParam {
     // Used for baked values. The expected type of the parameter.
     Type* type;
 
-    // Used to store interface specified with $T/Interface.
-    bh_arr(AstNode *) implicit_interfaces;
+    // Used to store interface specified with $T/Interface
+    // Can store extra args for $T/Interface(R)
+    bh_arr(ImplicitInterfaceConstraint) implicit_interface_constraints;
 };
 
 struct AstPolySolution {

--- a/compiler/include/astnodes.h
+++ b/compiler/include/astnodes.h
@@ -1408,7 +1408,7 @@ struct AstPolyParam {
     Type* type;
 
     // Used to store interface specified with $T/Interface.
-    AstNode *implicit_interface;
+    bh_arr(AstNode *) implicit_interfaces;
 };
 
 struct AstPolySolution {

--- a/compiler/src/doc.c
+++ b/compiler/src/doc.c
@@ -447,20 +447,23 @@ static void write_doc_constraints(Context *context, bh_buffer *buffer, Constrain
 
     if (poly_params) {
         bh_arr_each(AstPolyParam, poly_param, poly_params) {
-            if (!poly_param->implicit_interface) continue;
+          if (!poly_param->implicit_interfaces) continue;
 
-            bh_buffer_clear(&tmp_buffer);
-            write_type_node(context, &tmp_buffer, poly_param->implicit_interface);
-            bh_buffer_write_string(&tmp_buffer, "(");
+          // Generate constraint documentation for each interface
+          bh_arr_each(AstNode *, pinterface, poly_param->implicit_interfaces) {
+              bh_buffer_clear(&tmp_buffer);
+              write_type_node(context, &tmp_buffer, *pinterface);
+              bh_buffer_write_string(&tmp_buffer, "(");
 
-            poly_param->poly_sym->flags &= ~Ast_Flag_Symbol_Is_PolyVar;
-            write_type_node(context, &tmp_buffer, poly_param->poly_sym);
-            poly_param->poly_sym->flags |= Ast_Flag_Symbol_Is_PolyVar;
+              poly_param->poly_sym->flags &= ~Ast_Flag_Symbol_Is_PolyVar;
+              write_type_node(context, &tmp_buffer, poly_param->poly_sym);
+              poly_param->poly_sym->flags |= Ast_Flag_Symbol_Is_PolyVar;
 
-            bh_buffer_write_string(&tmp_buffer, ")");
-            write_string(buffer, tmp_buffer.length, (char *) tmp_buffer.data);
+              bh_buffer_write_string(&tmp_buffer, ")");
+              write_string(buffer, tmp_buffer.length, (char *) tmp_buffer.data);
 
-            constraint_count += 1;
+              constraint_count += 1;
+          }
         }
     }
 


### PR DESCRIPTION
1. Allows for passing a list of interfaces, enclosed in braces, next to polymorphic variables in function heads after the `/` token:
```fs
my_func :: (x: $T/{Addable, Subtractable}) -> T
```
2. Allows for passing types to interfaces next to polymorphic variables in function heads after the `/` token where all passed types fill the argument slots after the first type argument:
```fs
my_func :: (x: $T/{Handles(i32), ConvertibleTo(bool)}) -> T
// equivalent to:
// where Handles(T, i32), ConvertibleTo(T, bool)

my_func :: (x: $T/ResultsIn(str)) -> str
// equivalent to:
// where ResultsIn(T, str)
``` 